### PR TITLE
Add a method purgeTilesFromBefore:(NSDate*) to RMDatabaseCache

### DIFF
--- a/MapView/Map/RMDatabaseCache.h
+++ b/MapView/Map/RMDatabaseCache.h
@@ -48,4 +48,6 @@
 -(void) setCapacity: (NSUInteger) theCapacity;
 -(void) setMinimalPurge: (NSUInteger) thePurgeMinimum;
 
+-(void) purgeTilesFromBefore: (NSDate*) date;
+
 @end

--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -162,6 +162,14 @@
 	return image;
 }
 
+-(void) purgeTilesFromBefore: (NSDate*) date
+{
+    @synchronized(self)
+    {
+        [dao purgeTilesFromBefore:date];
+    }
+}
+
 -(void)didReceiveMemoryWarning
 {
         @synchronized(self) 

--- a/MapView/Map/RMMapContents.m
+++ b/MapView/Map/RMMapContents.m
@@ -129,7 +129,17 @@
 	renderer = nil;
 	imagesOnScreen = nil;
 	tileLoader = nil;
-	screenScale =  ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] ? [[UIScreen mainScreen] scale] : 1.0);
+    
+    screenScale = 1.0;
+    if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
+    {
+        Class screenClass = NSClassFromString(@"UIScreen");
+        if ( screenClass != Nil)
+        {
+            id scale = [[screenClass mainScreen] valueForKey:@"scale"];
+            screenScale = [scale floatValue];
+        }    
+    }
 
 	boundingMask = RMMapMinWidthBound;
 

--- a/MapView/Map/RMPath.m
+++ b/MapView/Map/RMPath.m
@@ -64,9 +64,14 @@
 	enableRotation = YES;
 	isFirstPoint = YES;
 	
-    if ( [self respondsToSelector:@selector(setContentsScale:)] ) 
+    if ( [self respondsToSelector:@selector(setContentsScale:)] )
     {
-        self.contentsScale = ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] ? [[UIScreen mainScreen] scale] : 1.0);
+        Class screenClass = NSClassFromString(@"UIScreen");
+        if ( screenClass != Nil)
+        {
+            id scale = [[screenClass mainScreen] valueForKey:@"scale"];
+            [(id)self setValue:scale forKey:@"contentsScale"];
+        }
     }
 	
 	return self;

--- a/MapView/Map/RMTileCacheDAO.h
+++ b/MapView/Map/RMTileCacheDAO.h
@@ -41,6 +41,7 @@
 -(void) touchTile: (uint64_t) tileHash withDate: (NSDate*) date;
 -(void) addData: (NSData*) data LastUsed: (NSDate*)date ForTile: (uint64_t) tileHash;
 -(void) purgeTiles: (NSUInteger) count;
+-(void) purgeTilesFromBefore: (NSDate*) date;
 -(void) removeAllCachedImages;
 -(void)didReceiveMemoryWarning;
 


### PR DESCRIPTION
See #55. Some tile providers does not want us to store the tiles forever. This patch store the timestamp in the sqlite db and make it possible to purge old tiles
