### PR TITLE
Zoom level limits

### DIFF
--- a/MapView/Map/RMCircle.h
+++ b/MapView/Map/RMCircle.h
@@ -1,0 +1,67 @@
+//
+//  RMCircle.h
+//
+// Copyright (c) 2008-2010, Route-Me Contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import <Foundation/Foundation.h>
+#import "RMFoundation.h"
+#import "RMLatLong.h"
+#import "RMMapLayer.h"
+
+@class RMMapContents;
+
+
+@interface RMCircle : RMMapLayer <RMMovingMapLayer> {
+@private
+	RMMapContents* mapContents;
+	CAShapeLayer* shapeLayer;
+	
+	RMLatLong latLong;
+	RMProjectedPoint projectedLocation;
+	BOOL enableDragging;
+	BOOL enableRotation;
+	
+	UIColor* lineColor;
+	UIColor* fillColor;
+	CGFloat radiusInMeters;
+	CGFloat lineWidthInPixels;
+	BOOL scaleLineWidth;
+	
+	CGMutablePathRef circlePath;
+}
+
+@property (nonatomic, retain) CAShapeLayer* shapeLayer;
+@property (nonatomic, assign) RMProjectedPoint projectedLocation;
+@property (assign) BOOL enableDragging;
+@property (assign) BOOL enableRotation;
+@property (nonatomic, retain) UIColor* lineColor;
+@property (nonatomic, retain) UIColor* fillColor;
+@property (nonatomic, assign) CGFloat radiusInMeters;
+@property (nonatomic, assign) CGFloat lineWidthInPixels;
+
+- (id)initWithContents:(RMMapContents*)aContents radiusInMeters:(CGFloat)newRadiusInMeters latLong:(RMLatLong)newLatLong;
+- (void)moveToLatLong:(RMLatLong)newLatLong;
+
+@end

--- a/MapView/Map/RMCircle.m
+++ b/MapView/Map/RMCircle.m
@@ -1,0 +1,184 @@
+///
+//  RMCircle.m
+//
+// Copyright (c) 2008-2010, Route-Me Contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#import "RMCircle.h"
+#import "RMMapContents.h"
+#import "RMProjection.h"
+#import "RMMercatorToScreenProjection.h"
+
+#define kDefaultLineWidth 10
+#define kDefaultLineColor [UIColor blackColor]
+#define kDefaultFillColor [UIColor blueColor]
+
+@interface RMCircle ()
+
+- (void)updateCirclePath;
+
+@end
+
+
+@implementation RMCircle
+
+@synthesize shapeLayer;
+@synthesize projectedLocation;
+@synthesize enableDragging;
+@synthesize enableRotation;
+@synthesize lineColor;
+@synthesize fillColor;
+@synthesize radiusInMeters;
+@synthesize lineWidthInPixels;
+
+- (id)initWithContents:(RMMapContents*)aContents radiusInMeters:(CGFloat)newRadiusInMeters latLong:(RMLatLong)newLatLong {
+	self = [super init];
+	
+	if (self) {
+		CAShapeLayer* newShapeLayer = [[CAShapeLayer alloc] init];
+		shapeLayer = newShapeLayer;
+		[self addSublayer:newShapeLayer];
+		
+		mapContents = aContents;
+		radiusInMeters = newRadiusInMeters;
+		latLong = newLatLong;
+		projectedLocation = [[mapContents projection] latLongToPoint:newLatLong];
+		[self setPosition:[[mapContents mercatorToScreenProjection] projectXYPoint:projectedLocation]];
+//		DLog(@"Position: %f, %f", [self position].x, [self position].y);
+		
+		lineWidthInPixels = kDefaultLineWidth;
+		lineColor = kDefaultLineColor;
+		fillColor = kDefaultFillColor;
+		
+		scaleLineWidth = NO;
+		enableDragging = YES;
+		enableRotation = YES;
+		
+		circlePath = NULL;
+		[self updateCirclePath];
+	}
+	
+	return self;
+}
+
+- (void)dealloc {
+	[shapeLayer release];
+	shapeLayer = nil;
+	CGPathRelease(circlePath);
+	[lineColor release];
+	lineColor = nil;
+	[fillColor release];
+	fillColor = nil;
+	[super dealloc];
+}
+
+#pragma mark -
+
+- (void)updateCirclePath {
+	CGPathRelease(circlePath);
+	
+	CGMutablePathRef newPath = CGPathCreateMutable();
+	
+	CGFloat latRadians = latLong.latitude * M_PI / 180.0f;
+	CGFloat pixelRadius = radiusInMeters / cos(latRadians) / [mapContents metersPerPixel];
+//	DLog(@"Pixel Radius: %f", pixelRadius);
+	
+	CGRect rectangle = CGRectMake(self.position.x - pixelRadius, 
+								  self.position.y - pixelRadius, 
+								  (pixelRadius * 2), 
+								  (pixelRadius * 2));
+	
+	CGFloat offset = floorf(-lineWidthInPixels / 2.0f) - 2;
+//	DLog(@"Offset: %f", offset);
+	CGRect newBoundsRect = CGRectInset(rectangle, offset, offset);
+	[self setBounds:newBoundsRect];
+	
+//	DLog(@"Circle Rectangle: %f, %f, %f, %f", rectangle.origin.x, rectangle.origin.y, rectangle.size.width, rectangle.size.height);
+//	DLog(@"Bounds Rectangle: %f, %f, %f, %f", self.bounds.origin.x, self.bounds.origin.y, self.bounds.size.width, self.bounds.size.height);
+	
+	CGPathAddEllipseInRect(newPath, NULL, rectangle);
+	circlePath = newPath;
+	
+	[[self shapeLayer] setPath:newPath];
+	[[self shapeLayer] setFillColor:[fillColor CGColor]];
+	[[self shapeLayer] setStrokeColor:[lineColor CGColor]];
+	[[self shapeLayer] setLineWidth:lineWidthInPixels];
+}
+
+#pragma mark Accessors
+
+- (void)setProjectedLocation:(RMProjectedPoint)newProjectedLocation {
+	projectedLocation = newProjectedLocation;
+	
+	[self setPosition:[[mapContents mercatorToScreenProjection] projectXYPoint:projectedLocation]];
+}
+
+- (void)setLineColor:(UIColor*)newLineColor {
+	if (lineColor != newLineColor) {
+		[lineColor release];
+		lineColor = [newLineColor retain];
+		[self updateCirclePath];
+	}
+}
+
+- (void)setFillColor:(UIColor*)newFillColor {
+	if (fillColor != newFillColor) {
+		[fillColor release];
+		fillColor = [newFillColor retain];
+		[self updateCirclePath];
+	}
+}
+
+- (void)setRadiusInMeters:(CGFloat)newRadiusInMeters {
+	radiusInMeters = newRadiusInMeters;
+	[self updateCirclePath];
+}
+
+- (void)setLineWidthInPixels:(CGFloat)newLineWidthInPixels {
+	lineWidthInPixels = newLineWidthInPixels;
+	[self updateCirclePath];
+}
+
+#pragma mark Map Movement and Scaling
+
+- (void)moveBy:(CGSize)delta {
+	if (enableDragging) {
+		[super moveBy:delta];
+	}
+}
+
+- (void)zoomByFactor:(float)zoomFactor near:(CGPoint)center {
+	[super zoomByFactor:zoomFactor near:center];
+	
+	[self updateCirclePath];
+}
+
+- (void)moveToLatLong:(RMLatLong)newLatLong {
+	latLong = newLatLong;
+	[self setProjectedLocation:[[mapContents projection] latLongToPoint:newLatLong]];
+	[self setPosition:[[mapContents mercatorToScreenProjection] projectXYPoint:projectedLocation]];
+//	DLog(@"Position: %f, %f", [self position].x, [self position].y);
+}
+
+@end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		23A0AAE90EB90A99003A4521 /* RMFoundation.c in Sources */ = {isa = PBXBuildFile; fileRef = 23A0AAE80EB90A99003A4521 /* RMFoundation.c */; };
 		23A0AAEB0EB90AA6003A4521 /* RMFoundation.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A0AAEA0EB90AA6003A4521 /* RMFoundation.h */; };
 		23A0ABAA0EB923AF003A4521 /* RMLatLong.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A0ABA90EB923AF003A4521 /* RMLatLong.h */; };
+		25757F4F1291C8640083D504 /* RMCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 25757F4D1291C8640083D504 /* RMCircle.h */; };
+		25757F501291C8640083D504 /* RMCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = 25757F4E1291C8640083D504 /* RMCircle.m */; };
+		25757F521291C8850083D504 /* RMCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = 25757F4E1291C8640083D504 /* RMCircle.m */; };
 		2B2BADD70FA3B45A00EE37AA /* marker-X.png in Resources */ = {isa = PBXBuildFile; fileRef = 2B2BADD60FA3B45A00EE37AA /* marker-X.png */; };
 		2B5682720F68E36000E8DF40 /* RMOpenAerialMapSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B5682700F68E36000E8DF40 /* RMOpenAerialMapSource.h */; };
 		2B5682730F68E36000E8DF40 /* RMOpenAerialMapSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B5682710F68E36000E8DF40 /* RMOpenAerialMapSource.m */; };
@@ -226,6 +229,8 @@
 		23A0AAE80EB90A99003A4521 /* RMFoundation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = RMFoundation.c; sourceTree = "<group>"; };
 		23A0AAEA0EB90AA6003A4521 /* RMFoundation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMFoundation.h; sourceTree = "<group>"; };
 		23A0ABA90EB923AF003A4521 /* RMLatLong.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMLatLong.h; sourceTree = "<group>"; };
+		25757F4D1291C8640083D504 /* RMCircle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMCircle.h; sourceTree = "<group>"; };
+		25757F4E1291C8640083D504 /* RMCircle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMCircle.m; sourceTree = "<group>"; };
 		288765A40DF7441C002DB57D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		2B2BADD60FA3B45A00EE37AA /* marker-X.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "marker-X.png"; path = "../marker-X.png"; sourceTree = "<group>"; };
 		2B2BD41D0F79A95500B8B9A7 /* README-static-library-build.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = "README-static-library-build.rtf"; sourceTree = "<group>"; };
@@ -673,6 +678,8 @@
 				B8F3FC630EA2E792004D8F85 /* RMMarker.m */,
 				B8CEB1C30ED5A3480014C431 /* RMPath.h */,
 				B8CEB1C40ED5A3480014C431 /* RMPath.m */,
+				25757F4D1291C8640083D504 /* RMCircle.h */,
+				25757F4E1291C8640083D504 /* RMCircle.m */,
 			);
 			name = "Markers and other layers";
 			sourceTree = "<group>";
@@ -783,6 +790,7 @@
 				B1EB26C610B5D8E6009F8658 /* RMNotifications.h in Headers */,
 				D1437B35122869E400888DAE /* RMDBTileImage.h in Headers */,
 				D1437B37122869E400888DAE /* RMDBMapSource.h in Headers */,
+				25757F4F1291C8640083D504 /* RMCircle.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -976,6 +984,7 @@
 				2B8C8A260F8EB855002E8CF3 /* RouteMeTests.m in Sources */,
 				46B1C067117653930062018A /* GTMNSNumber+64Bit.m in Sources */,
 				46B1C075117653F10062018A /* GTMObjC2Runtime.m in Sources */,
+				25757F521291C8850083D504 /* RMCircle.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1025,6 +1034,7 @@
 				B1EB26C410B5D8C0009F8658 /* RMOpenCycleMapSource.m in Sources */,
 				D1437B34122869E400888DAE /* RMDBTileImage.m in Sources */,
 				D1437B36122869E400888DAE /* RMDBMapSource.m in Sources */,
+				25757F501291C8640083D504 /* RMCircle.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
A tester of mine noticed some "wonky" zoom behavior if they zoomed in too far.

The way I've been reproducing it is as follows:
1. Zoom in as far as possible. You can do this with pinch zoom, double-tap to zoom, or by calling RMMapView's zoomByFactor:near:animated: (I have zoom in/out buttons).
2. Try to zoom out and zoom back in (usually triggers, but I think using the zoomByFactor:near:animated: is the most reliable).

What typically happens is the zoom either "jumps" or starts to flicker between two zoom levels (it's hard to describe, but if you find it, you'll probably recognize it). It is sometimes possible to still zoom out, but it usually seems to get stuck in this behavior.

I noticed Michael added something similar in commit 15f6245f64b70dd67dc5c3d859beb730e9c847d3, but that was in the MapView. I tested this issue with that, and it does not seem to fully prevent this issue.

This commit checks to make sure that the targetZoom is within minZoom and maxZoom (in RMMapContents zoomByFactor:near:animated:withCallback:). This check existed, but was only used if the zoom was NOT to be animated. I changed it to check the targetZoom regardless of whether the zoom is to be animated or not.
