### PR TITLE
Fixed zoom inaccuracy

### DIFF
--- a/MapView/Map/RMMapContents.m
+++ b/MapView/Map/RMMapContents.m
@@ -526,9 +526,10 @@
 {
 	double zoomIncr = [[[timer userInfo] objectForKey:@"zoomIncr"] doubleValue];
 	double targetZoom = [[[timer userInfo] objectForKey:@"targetZoom"] doubleValue];
-
-	if ((zoomIncr > 0 && [self zoom] >= targetZoom) || (zoomIncr < 0 && [self zoom] <= targetZoom))
+    
+	if ((zoomIncr > 0 && [self zoom] >= targetZoom-1.0e-6) || (zoomIncr < 0 && [self zoom] <= targetZoom+1.0e-6))
 	{
+        if ( [self zoom] != targetZoom ) [self setZoom:targetZoom];
 		NSDictionary * userInfo = [[timer userInfo] retain];
 		[timer invalidate];	// ASAP
 		id<RMMapContentsAnimationCallback> callback = [userInfo objectForKey:@"callback"];


### PR DESCRIPTION
Double-tap zoom was wildly inaccurate - rather than moving in to the next native tile zoom level, it was overshooting. The result is constantly fuzzy tiles when zooming.

This fixes that by rounding the calculated number of animation steps (there's no such thing as a non-integer number of timer callbacks!)
