### PR TITLE
setMetersPerPixel problem

### DIFF
--- a/MapView/Map/RMMapContents.m
+++ b/MapView/Map/RMMapContents.m
@@ -775,7 +775,7 @@
 
 -(void) setMetersPerPixel: (float) newMPP
 {
-        float zoomFactor = newMPP / self.metersPerPixel;
+        float zoomFactor = self.metersPerPixel / newMPP;
         CGPoint pivot = CGPointZero;
 
         [mercatorToScreenProjection setMetersPerPixel:newMPP];


### PR DESCRIPTION
Fix problem with setZoom/setMetersPerPixel seen when updating the slave map with the zoom level of the master map.

Without this fix, the slave map zooms the opposite way of the master map.
