### PR TITLE
new offline tile source: MBTiles

### DIFF
--- a/MapView/Map/RMMBTilesTileSource.h
+++ b/MapView/Map/RMMBTilesTileSource.h
@@ -1,0 +1,77 @@
+//
+//  RMMBTilesTileSource.h
+//
+//  Created by Justin R. Miller on 6/18/10.
+//  Copyright 2010, Code Sorcery Workshop, LLC and Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the names of Code Sorcery Workshop, LLC or Development Seed,
+//        Inc., nor the names of its contributors may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//  http://mapbox.com/documentation/mbtiles-file-format
+//
+
+#import <Foundation/Foundation.h>
+#import "RMTileSource.h"
+
+@class RMFractalTileProjection;
+@class FMDatabase;
+
+#define kMBTilesDefaultTileSize 256
+#define kMBTilesDefaultMinTileZoom 0
+#define kMBTilesDefaultMaxTileZoom 18
+#define kMBTilesDefaultLatLonBoundingBox ((RMSphericalTrapezium){ .northeast = { .latitude =  90, .longitude =  180 }, \
+                                                                  .southwest = { .latitude = -90, .longitude = -180 } })
+
+@interface RMMBTilesTileSource : NSObject <RMTileSource>
+{
+    RMFractalTileProjection *tileProjection;
+    FMDatabase *db;
+}
+
+- (id)initWithTileSetURL:(NSURL *)tileSetURL;
+- (int)tileSideLength;
+- (void)setTileSideLength:(NSUInteger)aTileSideLength;
+- (RMTileImage *)tileImage:(RMTile)tile;
+- (NSString *)tileURL:(RMTile)tile;
+- (NSString *)tileFile:(RMTile)tile;
+- (NSString *)tilePath;
+- (id <RMMercatorToTileProjection>)mercatorToTileProjection;
+- (RMProjection *)projection;
+- (float)minZoom;
+- (float)maxZoom;
+- (void)setMinZoom:(NSUInteger)aMinZoom;
+- (void)setMaxZoom:(NSUInteger)aMaxZoom;
+- (RMSphericalTrapezium)latitudeLongitudeBoundingBox;
+- (void)didReceiveMemoryWarning;
+- (NSString *)uniqueTilecacheKey;
+- (NSString *)shortName;
+- (NSString *)longDescription;
+- (NSString *)shortAttribution;
+- (NSString *)longAttribution;
+- (void)removeAllCachedImages;
+
+@end

--- a/MapView/Map/RMMBTilesTileSource.m
+++ b/MapView/Map/RMMBTilesTileSource.m
@@ -1,0 +1,258 @@
+//
+//  RMMBTilesTileSource.m
+//
+//  Created by Justin R. Miller on 6/18/10.
+//  Copyright 2010, Code Sorcery Workshop, LLC and Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the names of Code Sorcery Workshop, LLC or Development Seed,
+//        Inc., nor the names of its contributors may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "RMMBTilesTileSource.h"
+#import "RMTileImage.h"
+#import "RMProjection.h"
+#import "RMFractalTileProjection.h"
+#import "FMDatabase.h"
+
+#pragma mark -
+
+@implementation RMMBTilesTileSource
+
+- (id)initWithTileSetURL:(NSURL *)tileSetURL
+{
+	if ( ! [super init])
+		return nil;
+	
+	tileProjection = [[RMFractalTileProjection alloc] initFromProjection:[self projection] 
+                                                          tileSideLength:kMBTilesDefaultTileSize 
+                                                                 maxZoom:kMBTilesDefaultMaxTileZoom 
+                                                                 minZoom:kMBTilesDefaultMinTileZoom];
+	
+    db = [[FMDatabase databaseWithPath:[tileSetURL relativePath]] retain];
+    
+    if ( ! [db open])
+        return nil;
+    
+	return self;
+}
+
+- (void)dealloc
+{
+	[tileProjection release];
+    
+    [db close];
+    [db release];
+    
+	[super dealloc];
+}
+
+- (int)tileSideLength
+{
+	return tileProjection.tileSideLength;
+}
+
+- (void)setTileSideLength:(NSUInteger)aTileSideLength
+{
+	[tileProjection setTileSideLength:aTileSideLength];
+}
+
+- (RMTileImage *)tileImage:(RMTile)tile
+{
+    NSAssert4(((tile.zoom >= self.minZoom) && (tile.zoom <= self.maxZoom)),
+			  @"%@ tried to retrieve tile with zoomLevel %d, outside source's defined range %f to %f", 
+			  self, tile.zoom, self.minZoom, self.maxZoom);
+
+    NSInteger zoom = tile.zoom;
+    NSInteger x    = tile.x;
+    NSInteger y    = pow(2, zoom) - tile.y - 1;
+
+    FMResultSet *results = [db executeQuery:@"select tile_data from tiles where zoom_level = ? and tile_column = ? and tile_row = ?", 
+                               [NSNumber numberWithFloat:zoom], 
+                               [NSNumber numberWithFloat:x], 
+                               [NSNumber numberWithFloat:y]];
+    
+    if ([db hadError])
+        return [RMTileImage dummyTile:tile];
+    
+    [results next];
+    
+    NSData *data = [results dataForColumn:@"tile_data"];
+
+    RMTileImage *image;
+    
+    if ( ! data)
+        image = [RMTileImage dummyTile:tile];
+    
+    else
+        image = [RMTileImage imageForTile:tile withData:data];
+    
+    [results close];
+    
+    return image;
+}
+
+- (NSString *)tileURL:(RMTile)tile
+{
+    return nil;
+}
+
+- (NSString *)tileFile:(RMTile)tile
+{
+    return nil;
+}
+
+- (NSString *)tilePath
+{
+    return nil;
+}
+
+- (id <RMMercatorToTileProjection>)mercatorToTileProjection
+{
+	return [[tileProjection retain] autorelease];
+}
+
+- (RMProjection *)projection
+{
+	return [RMProjection googleProjection];
+}
+
+- (float)minZoom
+{
+    FMResultSet *results = [db executeQuery:@"select min(zoom_level) from tiles"];
+    
+    if ([db hadError])
+        return kMBTilesDefaultMinTileZoom;
+    
+    [results next];
+    
+    double minZoom = [results doubleForColumnIndex:0];
+    
+    [results close];
+    
+    return (float)minZoom;
+}
+
+- (float)maxZoom
+{
+    FMResultSet *results = [db executeQuery:@"select max(zoom_level) from tiles"];
+    
+    if ([db hadError])
+        return kMBTilesDefaultMaxTileZoom;
+
+    [results next];
+    
+    double maxZoom = [results doubleForColumnIndex:0];
+    
+    [results close];
+    
+    return (float)maxZoom;
+}
+
+- (void)setMinZoom:(NSUInteger)aMinZoom
+{
+    [tileProjection setMinZoom:aMinZoom];
+}
+
+- (void)setMaxZoom:(NSUInteger)aMaxZoom
+{
+    [tileProjection setMaxZoom:aMaxZoom];
+}
+
+- (RMSphericalTrapezium)latitudeLongitudeBoundingBox
+{
+    return kMBTilesDefaultLatLonBoundingBox;
+}
+
+- (void)didReceiveMemoryWarning
+{
+    NSLog(@"*** didReceiveMemoryWarning in %@", [self class]);
+}
+
+- (NSString *)uniqueTilecacheKey
+{
+    return [NSString stringWithFormat:@"MBTiles%@", [[db databasePath] lastPathComponent]];
+}
+
+- (NSString *)shortName
+{
+    FMResultSet *results = [db executeQuery:@"select value from metadata where name = 'name'"];
+    
+    if ([db hadError])
+        return @"Unknown MBTiles";
+    
+    [results next];
+    
+    NSString *shortName = [results stringForColumnIndex:0];
+    
+    [results close];
+    
+    return shortName;
+}
+
+- (NSString *)longDescription
+{
+    FMResultSet *results = [db executeQuery:@"select value from metadata where name = 'description'"];
+    
+    if ([db hadError])
+        return @"Unknown MBTiles description";
+    
+    [results next];
+    
+    NSString *description = [results stringForColumnIndex:0];
+    
+    [results close];
+    
+    return [NSString stringWithFormat:@"%@ - %@", [self shortName], description];
+}
+
+- (NSString *)shortAttribution
+{
+    FMResultSet *results = [db executeQuery:@"select value from metadata where name = 'attribution'"];
+    
+    if ([db hadError])
+        return @"Unknown MBTiles attribution";
+    
+    [results next];
+    
+    NSString *attribution = [results stringForColumnIndex:0];
+    
+    [results close];
+    
+    return attribution;
+}
+
+- (NSString *)longAttribution
+{
+    return [NSString stringWithFormat:@"%@ - %@", [self shortName], [self shortAttribution]];
+}
+
+- (void)removeAllCachedImages
+{
+    NSLog(@"*** removeAllCachedImages in %@", [self class]);
+}
+
+@end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -192,6 +192,9 @@
 		D1437B35122869E400888DAE /* RMDBTileImage.h in Headers */ = {isa = PBXBuildFile; fileRef = D1437B31122869E400888DAE /* RMDBTileImage.h */; };
 		D1437B36122869E400888DAE /* RMDBMapSource.m in Sources */ = {isa = PBXBuildFile; fileRef = D1437B32122869E400888DAE /* RMDBMapSource.m */; };
 		D1437B37122869E400888DAE /* RMDBMapSource.h in Headers */ = {isa = PBXBuildFile; fileRef = D1437B33122869E400888DAE /* RMDBMapSource.h */; };
+		DD55FD1412FB40E000B6FE24 /* RMMBTilesTileSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD55FD1212FB40E000B6FE24 /* RMMBTilesTileSource.m */; };
+		DD55FD1512FB40E000B6FE24 /* RMMBTilesTileSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DD55FD1312FB40E000B6FE24 /* RMMBTilesTileSource.h */; };
+		DD55FD1612FB40E000B6FE24 /* RMMBTilesTileSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD55FD1212FB40E000B6FE24 /* RMMBTilesTileSource.m */; };
 		F5C12D2A0F8A86CA00A894D2 /* RMGeoHash.h in Headers */ = {isa = PBXBuildFile; fileRef = F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */; };
 		F5C12D2B0F8A86CA00A894D2 /* RMGeoHash.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */; };
 /* End PBXBuildFile section */
@@ -366,6 +369,8 @@
 		D1437B31122869E400888DAE /* RMDBTileImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMDBTileImage.h; sourceTree = "<group>"; };
 		D1437B32122869E400888DAE /* RMDBMapSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMDBMapSource.m; sourceTree = "<group>"; };
 		D1437B33122869E400888DAE /* RMDBMapSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMDBMapSource.h; sourceTree = "<group>"; };
+		DD55FD1212FB40E000B6FE24 /* RMMBTilesTileSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMMBTilesTileSource.m; sourceTree = "<group>"; };
+		DD55FD1312FB40E000B6FE24 /* RMMBTilesTileSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMMBTilesTileSource.h; sourceTree = "<group>"; };
 		F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMGeoHash.h; sourceTree = "<group>"; };
 		F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMGeoHash.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -617,6 +622,8 @@
 				2B5682710F68E36000E8DF40 /* RMOpenAerialMapSource.m */,
 				2599740712EB966400816331 /* RMSpatialCloudMapSource.h */,
 				2599740812EB966400816331 /* RMSpatialCloudMapSource.m */,
+				DD55FD1312FB40E000B6FE24 /* RMMBTilesTileSource.h */,
+				DD55FD1212FB40E000B6FE24 /* RMMBTilesTileSource.m */,
 			);
 			name = "Tile Source";
 			sourceTree = "<group>";
@@ -799,6 +806,7 @@
 				D1437B37122869E400888DAE /* RMDBMapSource.h in Headers */,
 				25757F4F1291C8640083D504 /* RMCircle.h in Headers */,
 				2599740912EB966400816331 /* RMSpatialCloudMapSource.h in Headers */,
+				DD55FD1512FB40E000B6FE24 /* RMMBTilesTileSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -994,6 +1002,7 @@
 				46B1C075117653F10062018A /* GTMObjC2Runtime.m in Sources */,
 				25757F521291C8850083D504 /* RMCircle.m in Sources */,
 				2599740B12EB967600816331 /* RMSpatialCloudMapSource.m in Sources */,
+				DD55FD1612FB40E000B6FE24 /* RMMBTilesTileSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1045,6 +1054,7 @@
 				D1437B36122869E400888DAE /* RMDBMapSource.m in Sources */,
 				25757F501291C8640083D504 /* RMCircle.m in Sources */,
 				2702E97012EB9DB50027A466 /* RMSpatialCloudMapSource.m in Sources */,
+				DD55FD1412FB40E000B6FE24 /* RMMBTilesTileSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.markdown
+++ b/README.markdown
@@ -5,8 +5,10 @@ Route-Me is an open source map library that runs natively on iOS.  It's designed
 to look and feel much like the inbuilt iOS map library, but it's entirely open,
 and works with any map source.
 
-Currently, [OpenStreetMap][1], [Microsoft VirtualEarth][2] and [CloudMade][3] are
-supported as map sources.
+Currently, [OpenStreetMap][1], [Microsoft VirtualEarth][2], [CloudMade][3],
+[OpenAerialMap][4], [OpenCycleMap][5], [SpatialCloud][6], and two offline,
+database-backed formats (DBMap and [MBTiles][7]) are supported as map
+sources.
 
 Please note that you are responsible for getting permission to use the map data,
 and for ensuring your use adheres to the relevant terms of use.
@@ -15,6 +17,10 @@ and for ensuring your use adheres to the relevant terms of use.
    [1]: http://www.openstreetmap.org/index.html
    [2]: http://maps.live.com/
    [3]: http://www.cloudmade.com/
+   [4]: http://www.openaerialmap.org/
+   [5]: http://www.opencyclemap.org/
+   [6]: http://www.spatialcloud.com/
+   [7]: http://mapbox.com/documentation/mbtiles-file-format
 
 
 Installing


### PR DESCRIPTION
We've been working hard on a SQLite-backed tile source called MBTiles, documented here: 

http://mapbox.com/documentation/mbtiles-file-format

This is currently in production with the [MapBox iPad app](http://mapbox.com/ipad) (which uses route-me) and is a proposed open standard for dealing with offline tiles. 

A bit more background on the format: http://developmentseed.org/search?search=mbtiles

Free, open source tools are in active development, to be released soon, around making it much easier to create these tiles. 
