### PR TITLE
Fix for Issue #89: Clamp zoom

### DIFF
--- a/MapView/Map/RMMapContents.m
+++ b/MapView/Map/RMMapContents.m
@@ -480,8 +480,17 @@
 		return;
 	}
 	// clamp zoom to remain below or equal to maxZoom after zoomAfter will be applied
+	// Set targetZoom to maxZoom so the map zooms to its maximum
 	if(targetZoom > [self maxZoom]){
 		zoomFactor = exp2f([self maxZoom] - [self zoom]);
+		targetZoom = [self maxZoom];
+	}
+	
+	// clamp zoom to remain above or equal to minZoom after zoomAfter will be applied
+	// Set targetZoom to minZoom so the map zooms to its maximum
+	if(targetZoom < [self minZoom]){
+		zoomFactor = 1/exp2f([self zoom] - [self minZoom]);
+		targetZoom = [self minZoom];
 	}
 
     if ([self shouldZoomToTargetZoom:targetZoom withZoomFactor:zoomFactor])

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -293,6 +293,11 @@
 			_zoomFactor = exp2f([self.contents maxZoom] - [self.contents zoom]);
 		}
 		
+		// clamp zoom to remain above or equal to minZoom after zoomAfter will be applied
+		if(targetZoom < [self.contents minZoom]){
+			zoomFactor = 1/exp2f([self.contents zoom] - [self.contents minZoom]);
+		}
+		
 		//bools for syntactical sugar to understand the logic in the if statement below
 		BOOL zoomAtMax = ([self.contents  zoom] == [self.contents  maxZoom]);
 		BOOL zoomAtMin = ([self.contents  zoom] == [self.contents  minZoom]);


### PR DESCRIPTION
If the minimum or maximum zoom levels of the map are different than the default values, the map will sometimes get "stuck" when zoomed in or out all the way, due to the zoom level not being clamped. This patch will clamp the zoom levels between the minimum and maximum zoom levels.
