### PR TITLE
Added a callback method mapViewRegionDidChange: to RMMapViewDelegate protocol

### DIFF
--- a/MapView/Map/RMMapContents.h
+++ b/MapView/Map/RMMapContents.h
@@ -66,6 +66,7 @@ enum {
 @protocol RMMapContentsAnimationCallback <NSObject>
 @optional
 - (void)animationFinishedWithZoomFactor:(float)zoomFactor near:(CGPoint)p;
+- (void)animationStepped;
 @end
 
 

--- a/MapView/Map/RMMapContents.m
+++ b/MapView/Map/RMMapContents.m
@@ -528,21 +528,26 @@
 	double zoomIncr = [[[timer userInfo] objectForKey:@"zoomIncr"] doubleValue];
 	double targetZoom = [[[timer userInfo] objectForKey:@"targetZoom"] doubleValue];
     
+	NSDictionary *userInfo = [[[timer userInfo] retain] autorelease];
+	id<RMMapContentsAnimationCallback> callback = [userInfo objectForKey:@"callback"];
+
 	if ((zoomIncr > 0 && [self zoom] >= targetZoom-1.0e-6) || (zoomIncr < 0 && [self zoom] <= targetZoom+1.0e-6))
 	{
         if ( [self zoom] != targetZoom ) [self setZoom:targetZoom];
-		NSDictionary * userInfo = [[timer userInfo] retain];
 		[timer invalidate];	// ASAP
-		id<RMMapContentsAnimationCallback> callback = [userInfo objectForKey:@"callback"];
-		if (callback && [callback respondsToSelector:@selector(animationFinishedWithZoomFactor:near:)]) {
+		if ([callback respondsToSelector:@selector(animationFinishedWithZoomFactor:near:)])
+		{
 			[callback animationFinishedWithZoomFactor:[[userInfo objectForKey:@"factor"] floatValue] near:[[userInfo objectForKey:@"pivot"] CGPointValue]];
 		}
-		[userInfo release];
 	}
 	else
 	{
 		float zoomFactorStep = exp2f(zoomIncr);
 		[self zoomByFactor:zoomFactorStep near:[[[timer userInfo] objectForKey:@"pivot"] CGPointValue] animated:NO];
+		if ([callback respondsToSelector:@selector(animationStepped)])
+		{
+			[callback animationStepped];
+		}
 	}
 }
 

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -136,6 +136,7 @@ typedef struct {
 	BOOL _delegateHasAfterMapMove;
 	BOOL _delegateHasBeforeMapZoomByFactor;
 	BOOL _delegateHasAfterMapZoomByFactor;
+	BOOL _delegateHasMapViewRegionDidChange;
 	BOOL _delegateHasBeforeMapRotate;
 	BOOL _delegateHasAfterMapRotate;
 	BOOL _delegateHasDoubleTapOnMap;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -182,6 +182,8 @@
 	
 	_delegateHasBeforeMapZoomByFactor = [(NSObject*) delegate respondsToSelector: @selector(beforeMapZoom: byFactor: near:)];
 	_delegateHasAfterMapZoomByFactor  = [(NSObject*) delegate respondsToSelector: @selector(afterMapZoom: byFactor: near:)];
+	
+	_delegateHasMapViewRegionDidChange = [delegate respondsToSelector:@selector(mapViewRegionDidChange:)];
 
 	_delegateHasBeforeMapRotate  = [(NSObject*) delegate respondsToSelector: @selector(beforeMapRotate: fromAngle:)];
 	_delegateHasAfterMapRotate  = [(NSObject*) delegate respondsToSelector: @selector(afterMapRotate: toAngle:)];
@@ -212,12 +214,14 @@
 	if (_delegateHasBeforeMapMove) [delegate beforeMapMove: self];
 	[self.contents moveToProjectedPoint:aPoint];
 	if (_delegateHasAfterMapMove) [delegate afterMapMove: self];
+	if (_delegateHasMapViewRegionDidChange) [delegate mapViewRegionDidChange:self];
 }
 -(void) moveToLatLong: (CLLocationCoordinate2D) point
 {
 	if (_delegateHasBeforeMapMove) [delegate beforeMapMove: self];
 	[self.contents moveToLatLong:point];
 	if (_delegateHasAfterMapMove) [delegate afterMapMove: self];
+	if (_delegateHasMapViewRegionDidChange) [delegate mapViewRegionDidChange:self];
 }
 
 -(void)setConstraintsSW:(CLLocationCoordinate2D)sw NE:(CLLocationCoordinate2D)ne
@@ -269,6 +273,7 @@
 	if (_delegateHasBeforeMapMove) [delegate beforeMapMove: self];
 	[self.contents moveBy:delta];
 	if (_delegateHasAfterMapMove) [delegate afterMapMove: self];
+	if (_delegateHasMapViewRegionDidChange) [delegate mapViewRegionDidChange:self];
 }
  
 - (void)zoomByFactor: (float) zoomFactor near:(CGPoint) center
@@ -345,9 +350,12 @@
 	}
 	
 	if (_delegateHasBeforeMapZoomByFactor) [delegate beforeMapZoom: self byFactor: zoomFactor near: center];
-	[self.contents zoomByFactor:zoomFactor near:center animated:animated withCallback:(animated && _delegateHasAfterMapZoomByFactor)?self:nil];
+	[self.contents zoomByFactor:zoomFactor near:center animated:animated withCallback:(animated && (_delegateHasAfterMapZoomByFactor || _delegateHasMapViewRegionDidChange))?self:nil];
 	if (!animated)
+	{
 		if (_delegateHasAfterMapZoomByFactor) [delegate afterMapZoom: self byFactor: zoomFactor near: center];
+		if (_delegateHasMapViewRegionDidChange) [delegate mapViewRegionDidChange:self];
+	}
 }
 
 
@@ -359,6 +367,9 @@
 		[delegate afterMapZoom: self byFactor: zoomFactor near: p];
 }
 
+- (void)animationStepped {
+	if (_delegateHasMapViewRegionDidChange) [delegate mapViewRegionDidChange:self];
+}
 
 #pragma mark Event handling
 

--- a/MapView/Map/RMMapViewDelegate.h
+++ b/MapView/Map/RMMapViewDelegate.h
@@ -31,7 +31,7 @@
 @class RMMarker;
 
 /// Use this for notifications of map panning, zooming, and taps on the RMMapView.
-@protocol RMMapViewDelegate 
+@protocol RMMapViewDelegate <NSObject>
 
 @optional
 
@@ -40,6 +40,14 @@
 
 - (void) beforeMapZoom: (RMMapView*) map byFactor: (float) zoomFactor near:(CGPoint) center;
 - (void) afterMapZoom: (RMMapView*) map byFactor: (float) zoomFactor near:(CGPoint) center;
+
+/*
+ \brief Tells the delegate that the region displayed by the map view just changed.
+ \details This method is called whenever the currently displayed map region changes. 
+ During scrolling and zooming, this method may be called many times to report updates to the map position. 
+ Therefore, your implementation of this method should be as lightweight as possible to avoid affecting scrolling and zooming performance.
+ */
+- (void)mapViewRegionDidChange:(RMMapView *)mapView;
 
 - (void) beforeMapRotate: (RMMapView*) map fromAngle: (CGFloat) angle;
 - (void) afterMapRotate: (RMMapView*) map toAngle: (CGFloat) angle;


### PR DESCRIPTION
A message mapViewRegionDidChange: is sent to the delegate every a visible region of a map view changes. During scrolling and/or zooming it is sent may be send several times. A message is set even is animation is in progress.

I personally use this callback to track any changes to visible region, because it immediately affects marker positions. I need to adjust my callout view position, when it is visible.
