### PR TITLE
Automatic marker ordering

### DIFF
--- a/MapView/Map/RMLayerCollection.h
+++ b/MapView/Map/RMLayerCollection.h
@@ -68,6 +68,7 @@
 - (void) setRotationOfAllSublayers:(float) angle;
 //-(void) drawRect: (CGRect)rect;
 //-(CALayer*) layer;
+/// Orders layers in the collection based on their position in the map, prioritizing instances/subclass instances of RMMarker above other layers. This is called automatically in addSublayer.
 - (void)orderLayers;
 
 @end

--- a/MapView/Map/RMLayerCollection.h
+++ b/MapView/Map/RMLayerCollection.h
@@ -68,5 +68,6 @@
 - (void) setRotationOfAllSublayers:(float) angle;
 //-(void) drawRect: (CGRect)rect;
 //-(CALayer*) layer;
+- (void)orderLayers;
 
 @end

--- a/MapView/Map/RMLayerCollection.m
+++ b/MapView/Map/RMLayerCollection.m
@@ -214,12 +214,12 @@ NSInteger layerSort(id num1, id num2, void *context) {
 		RMMarker *first = (RMMarker *)num1;
 		RMMarker *second = (RMMarker *)num2;
 
-		int my_pos    = first.projectedLocation.northing;
-		int their_pos = second.projectedLocation.northing;
+		double firstPos = first.projectedLocation.northing;
+		double secondPos = second.projectedLocation.northing;
 
-		if (my_pos > their_pos) {
+		if (firstPos > secondPos) {
 			return NSOrderedAscending;
-		} else if (my_pos < their_pos) {
+		} else if (firstPos < secondPos) {
 			return NSOrderedDescending;
 		} else {
 			return NSOrderedSame;

--- a/MapView/Map/RMLayerCollection.m
+++ b/MapView/Map/RMLayerCollection.m
@@ -209,7 +209,7 @@
 }
 
 NSInteger layerSort(id num1, id num2, void *context) {
-	if ([[num1 class] isSubclassOfClass:[RMMarker class]] && [[num2 class] isSubclassOfClass:[RMMarker class]]) {
+	if ([num1 isKindOfClass:[RMMarker class]] && [num2 isKindOfClass:[RMMarker class]]) {
 		// if both are markers, order based on vertical map position
 		RMMarker *first = (RMMarker *)num1;
 		RMMarker *second = (RMMarker *)num2;
@@ -226,9 +226,9 @@ NSInteger layerSort(id num1, id num2, void *context) {
 		}
 	} else {
 		// if something isnt a marker, send to bottom
-		if ([[num1 class] isSubclassOfClass:[RMMarker class]]) {
+		if ([num1 isKindOfClass:[RMMarker class]]) {
 			return NSOrderedDescending;
-		} else if ([[num2 class] isSubclassOfClass:[RMMarker class]]) {
+		} else if ([num2 isKindOfClass:[RMMarker class]]) {
 			return NSOrderedAscending;
 		} else {
 			return NSOrderedSame;

--- a/MapView/Map/RMLayerCollection.m
+++ b/MapView/Map/RMLayerCollection.m
@@ -89,7 +89,6 @@
 	[self correctScreenPosition:layer];
 	[sublayers addObject:layer];
 	[super addSublayer:layer];
-  [self orderLayers];
 }
 }
 

--- a/MapView/Map/RMLayerCollection.m
+++ b/MapView/Map/RMLayerCollection.m
@@ -28,6 +28,7 @@
 #import "RMLayerCollection.h"
 #import "RMMapContents.h"
 #import "RMMercatorToScreenProjection.h"
+#import "RMMarker.h"
 
 @implementation RMLayerCollection
 
@@ -88,6 +89,7 @@
 	[self correctScreenPosition:layer];
 	[sublayers addObject:layer];
 	[super addSublayer:layer];
+  [self orderLayers];
 }
 }
 
@@ -204,6 +206,38 @@
 			}
 		}
 	}
+}
+
+NSInteger layerSort(id num1, id num2, void *context) {
+	if ([[num1 class] isSubclassOfClass:[RMMarker class]] && [[num2 class] isSubclassOfClass:[RMMarker class]]) {
+		// if both are markers, order based on vertical map position
+		RMMarker *first = (RMMarker *)num1;
+		RMMarker *second = (RMMarker *)num2;
+
+		int my_pos    = first.projectedLocation.northing;
+		int their_pos = second.projectedLocation.northing;
+
+		if (my_pos > their_pos) {
+			return NSOrderedAscending;
+		} else if (my_pos < their_pos) {
+			return NSOrderedDescending;
+		} else {
+			return NSOrderedSame;
+		}
+	} else {
+		// if something isnt a marker, send to bottom
+		if ([[num1 class] isSubclassOfClass:[RMMarker class]]) {
+			return NSOrderedDescending;
+		} else if ([[num2 class] isSubclassOfClass:[RMMarker class]]) {
+			return NSOrderedAscending;
+		} else {
+			return NSOrderedSame;
+		}
+	}
+}
+
+- (void)orderLayers {
+	self.sublayers = [self.sublayers sortedArrayUsingFunction:layerSort context:NULL];
 }
 
 @end


### PR DESCRIPTION
Hey there

I am using the route-me library in a project, and have found that markers need to be manually ordered.

This commit will make markers get automatically ordered based on vertical map position, and also puts them above other layers on the map to ensure that they look nice and are always available to receive touch events.

Was hoping this could be pulled into master if you agree that the functionality is required? Am also happy to receive suggestions/changes to this code.
