### PR TITLE
Line dash style for RMPath

### DIFF
--- a/MapView/Map/RMMapLayer.m
+++ b/MapView/Map/RMMapLayer.m
@@ -63,6 +63,9 @@
 
 - (void)zoomByFactor: (float) zoomFactor near:(CGPoint) pivot
 {
+    // a empty layer has size=(0,0) which cause divide by 0 if scaled
+    if(self.bounds.size.width == 0.0 || self.bounds.size.height == 0.0)
+        return;
 	self.position = RMScaleCGPointAboutPoint(self.position, zoomFactor, pivot);
 	self.bounds = RMScaleCGRectAboutPoint(self.bounds, zoomFactor, self.anchorPoint);
 }

--- a/MapView/Map/RMPath.h
+++ b/MapView/Map/RMPath.h
@@ -63,8 +63,17 @@
 	
 	//Line cap and join styles
 	CGLineCap lineCap;
-	CGLineJoin lineJoin;	
+	CGLineJoin lineJoin;
+    //Line dash style
+	CGFloat *_lineDashLengths;
+    CGFloat *_scaledLineDashLengths;
+    size_t _lineDashCount;
+    CGFloat lineDashPhase;
+    
 	BOOL scaleLineWidth;
+    /*! if YES line dashes will be scaled to keep a constant size if the layer is zoomed
+     */
+    BOOL scaleLineDash;
 	BOOL enableDragging;
 	BOOL enableRotation;
 	
@@ -79,6 +88,9 @@
 @property CGPathDrawingMode drawingMode;
 @property CGLineCap lineCap;
 @property CGLineJoin lineJoin;
+@property (nonatomic, readwrite, assign) NSArray *lineDashLengths;
+@property CGFloat lineDashPhase;
+@property BOOL scaleLineDash;
 @property float lineWidth;
 @property BOOL	scaleLineWidth;
 @property (nonatomic, assign) RMProjectedPoint projectedLocation;

--- a/MapView/Map/RMPath.m
+++ b/MapView/Map/RMPath.m
@@ -38,6 +38,8 @@
 @synthesize projectedLocation;
 @synthesize enableDragging;
 @synthesize enableRotation;
+@synthesize lineDashPhase;
+@synthesize scaleLineDash;
 
 #define kDefaultLineWidth 2
 
@@ -56,10 +58,15 @@
 	lineJoin = kCGLineJoinMiter;
 	lineColor = [UIColor blackColor];
 	fillColor = [UIColor redColor];
-	
+	_lineDashCount = 0;
+    _lineDashLengths = NULL;
+    _scaledLineDashLengths = NULL;
+    lineDashPhase = 0.0;
+    
 	self.masksToBounds = YES;
 	
 	scaleLineWidth = NO;
+    scaleLineDash = NO;
 	enableDragging = YES;
 	enableRotation = YES;
 	isFirstPoint = YES;
@@ -224,6 +231,7 @@
 - (void)drawInContext:(CGContextRef)theContext
 {
 	renderedScale = [contents metersPerPixel];
+    CGFloat *dashLengths = _lineDashLengths;
 	
 	float scale = 1.0f / [contents metersPerPixel];
 	
@@ -233,6 +241,13 @@
 	}
 	//NSLog(@"line width = %f, content scale = %f", scaledLineWidth, renderedScale);
 	
+    if(!scaleLineDash && _lineDashLengths) {
+        dashLengths = _scaledLineDashLengths;
+        for(size_t dashIndex=0; dashIndex<_lineDashCount; dashIndex++){
+            dashLengths[dashIndex] = _lineDashLengths[dashIndex]*renderedScale;
+        }
+    }
+    
 	CGContextScaleCTM(theContext, scale, scale);
 	
 	CGContextBeginPath(theContext);
@@ -243,6 +258,9 @@
 	CGContextSetLineJoin(theContext, lineJoin);	
 	CGContextSetStrokeColorWithColor(theContext, [lineColor CGColor]);
 	CGContextSetFillColorWithColor(theContext, [fillColor CGColor]);
+    if(_lineDashLengths){
+        CGContextSetLineDash(theContext, lineDashPhase, dashLengths, _lineDashCount);
+    }
 	
 	// according to Apple's documentation, DrawPath closes the path if it's a filled style, so a call to ClosePath isn't necessary
 	CGContextDrawPath(theContext, drawingMode);
@@ -320,6 +338,45 @@
         [fillColor release];
         fillColor = [aFillColor retain];
 		[self setNeedsDisplay];
+    }
+}
+
+- (NSArray *)lineDashLengths {
+    NSMutableArray *lengths = [NSMutableArray arrayWithCapacity:_lineDashCount];
+    for(size_t dashIndex=0; dashIndex<_lineDashCount; dashIndex++){
+        [lengths addObject:(id)[NSNumber numberWithFloat:_lineDashLengths[dashIndex]]];
+    }
+    return lengths;
+}
+- (void) setLineDashLengths:(NSArray *)lengths {
+    if(_lineDashLengths){
+        free(_lineDashLengths);
+        _lineDashLengths = NULL;
+
+    }
+    if(_scaledLineDashLengths){
+        free(_scaledLineDashLengths);
+        _scaledLineDashLengths = NULL;
+    }
+    _lineDashCount = [lengths count];
+    if(!_lineDashCount){
+        return;
+    }
+    _lineDashLengths = calloc(_lineDashCount, sizeof(CGFloat));
+    if(!scaleLineDash){
+        _scaledLineDashLengths = calloc(_lineDashCount, sizeof(CGFloat));
+    }
+
+    NSEnumerator *lengthEnumerator = [lengths objectEnumerator];
+    id lenObj;
+    size_t dashIndex = 0;
+    while ((lenObj = [lengthEnumerator nextObject])) {
+        if([lenObj isKindOfClass: [NSNumber class]]){
+            _lineDashLengths[dashIndex] = [lenObj floatValue];
+        } else {
+            _lineDashLengths[dashIndex] = 0.0;
+        }
+        dashIndex++;
     }
 }
 


### PR DESCRIPTION
Add (NSArray *)lineDashLengths, CGFloat lineDashPhase and BOOL scaleLineDash properties to RMPath class.
I chose to use a NSArray instead of the C array used by CGContextSetLineDash() to be more ObjectiveC.  

usage sample :

```
pathLayer.scaleLineDash = NO;
[pathLayer setLineDashLengths: [NSArray arrayWithObjects: [NSNumber numberWithFloat:10], [NSNumber numberWithFloat:10], nil]];
```
