### PR TITLE
fix for #105

### DIFF
--- a/MapView/Map/RMTileImageSet.m
+++ b/MapView/Map/RMTileImageSet.m
@@ -512,7 +512,7 @@
 
 		if (y >= zoomedMinY && y <= zoomedMaxY)
 		{
-			if (zoomedMinX <= zoomedMinY)
+			if (zoomedMinX <= zoomedMaxX)
 			{
 				if (x >= zoomedMinX && x <= zoomedMaxX)
 					continue;


### PR DESCRIPTION
My first commit is a rollback of Vlad's earlier rollback today. My second commit is a one-line fix that properly compares `zoomedMinX` to `zoomedMaxX` to determine if we are straddling the dateline. The August commit was comparing `zoomedMinX` to `zoomedMinY`, which caused all tiles to disappear when straddling the dateline (`x` of zero) and while also showing Antarctica (`y` of zero on OSM-style `y` counting) -- i.e., when involving the extreme southwest of the tile grid. This second commit properly removes only tiles outside of our visible `x` range. 
