### PR TITLE
Fixed RMDBMapSource reporting wrong bottom-left longitude

### DIFF
--- a/MapView/Map/RMDBMapSource.m
+++ b/MapView/Map/RMDBMapSource.m
@@ -124,7 +124,7 @@
 			topLeft.latitude = [self getPreferenceAsFloat:kCoverageTopLeftLatitudeKey];
 			topLeft.longitude = [self getPreferenceAsFloat:kCoverageTopLeftLongitudeKey];
 			bottomRight.latitude = [self getPreferenceAsFloat:kCoverageBottomRightLatitudeKey];
-			bottomRight.longitude = [self getPreferenceAsFloat:kCoverageBottomRightLatitudeKey];
+			bottomRight.longitude = [self getPreferenceAsFloat:kCoverageBottomRightLongitudeKey];
 			center.latitude = [self getPreferenceAsFloat:kCoverageCenterLatitudeKey];
 			center.longitude = [self getPreferenceAsFloat:kCoverageCenterLongitudeKey];
 			


### PR DESCRIPTION
Just a simple typo caused RMDBMapSource to return latitude instead of longitude for bottom right corner of map region
