### PR TITLE
Tilestream support

### DIFF
--- a/MapView/Map/RMTileStreamSource.h
+++ b/MapView/Map/RMTileStreamSource.h
@@ -32,6 +32,28 @@
 //
 //  http://mapbox.com/tilestream
 //
+//  This class supports both the paid, hosted version of TileStream, as well as the 
+//  open source, self-hosted version. 
+//
+//  When initializing an instance, pass in an info dictionary comprised of the 
+//  following keys. Unless otherwise specified, keys & values are exactly as 
+//  returned by the TileStream REST API.
+//
+//  Example: http://tiles.mapbox.com/mapbox/api/v1/Tileset/geography-class
+//
+//  Required info dictionary keys:
+//
+//    `name`
+//    `id`
+//    `version`
+//    `description`
+//    `attribution`
+//    `type`
+//    `minzoom`
+//    `maxzoom`
+//    `bounds`
+//    `tileURL` (choose a single value from `tiles` as returned by the API)
+//
 
 #import "RMAbstractMercatorWebSource.h"
 

--- a/MapView/Map/RMTileStreamSource.h
+++ b/MapView/Map/RMTileStreamSource.h
@@ -1,0 +1,61 @@
+//
+//  RMTileStreamSource.h
+//
+//  Created by Justin R. Miller on 5/17/11.
+//  Copyright 2011, Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the name of Development Seed, Inc., nor the names of its
+//        contributors may be used to endorse or promote products derived from
+//        this software without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//  http://mapbox.com/tilestream
+//
+
+#import "RMAbstractMercatorWebSource.h"
+
+#define kTileStreamDefaultTileSize 256
+#define kTileStreamDefaultMinTileZoom 0
+#define kTileStreamDefaultMaxTileZoom 18
+#define kTileStreamDefaultLatLonBoundingBox ((RMSphericalTrapezium){ .northeast = { .latitude =  85, .longitude =  180 }, \
+                                                                     .southwest = { .latitude = -85, .longitude = -180 } })
+
+typedef enum {
+    RMTileStreamLayerTypeBaselayer = 0,
+    RMTileStreamLayerTypeOverlay   = 1,
+} RMTileStreamLayerType;
+
+@interface RMTileStreamSource : RMAbstractMercatorWebSource <RMAbstractMercatorWebSource>
+{
+    NSDictionary *infoDictionary;
+}
+
+- (id)initWithInfo:(NSDictionary *)info;
+- (id)initWithReferenceURL:(NSURL *)referenceURL;
+- (RMTileStreamLayerType)layerType;
+- (BOOL)coversFullWorld;
+
+@property (nonatomic, readonly, retain) NSDictionary *infoDictionary;
+
+@end

--- a/MapView/Map/RMTileStreamSource.m
+++ b/MapView/Map/RMTileStreamSource.m
@@ -1,0 +1,162 @@
+//
+//  RMTileStreamSource.h
+//
+//  Created by Justin R. Miller on 5/17/11.
+//  Copyright 2011, Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the name of Development Seed, Inc., nor the names of its
+//        contributors may be used to endorse or promote products derived from
+//        this software without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "RMTileStreamSource.h"
+
+@interface RMTileStreamSource (RMTileStreamSourcePrivate)
+
+@property (nonatomic, retain) NSDictionary *infoDictionary;
+
+@end
+
+#pragma mark -
+
+@implementation RMTileStreamSource
+
+@synthesize infoDictionary;
+
+- (id)initWithInfo:(NSDictionary *)info
+{
+	if (self = [super init])
+        infoDictionary = [[NSDictionary dictionaryWithDictionary:info] retain];
+    
+	return self;
+}
+
+- (id)initWithReferenceURL:(NSURL *)referenceURL
+{
+    return [self initWithInfo:[NSDictionary dictionaryWithContentsOfURL:referenceURL]];
+}
+
+- (void)dealloc
+{
+    [infoDictionary release];
+    
+    [super dealloc];
+}
+
+#pragma mark 
+
+- (NSString *)tileURL:(RMTile)tile
+{
+    // flip y value per OSM-style
+    //
+    NSInteger zoom = tile.zoom;
+    NSInteger x    = tile.x;
+    NSInteger y    = pow(2, zoom) - tile.y - 1;
+    
+    NSString *tileURLString = [self.infoDictionary objectForKey:@"tileURL"];
+    
+    tileURLString = [tileURLString stringByReplacingOccurrencesOfString:@"{z}" withString:[[NSNumber numberWithInteger:zoom] stringValue]];
+    tileURLString = [tileURLString stringByReplacingOccurrencesOfString:@"{x}" withString:[[NSNumber numberWithInteger:x]    stringValue]];
+    tileURLString = [tileURLString stringByReplacingOccurrencesOfString:@"{y}" withString:[[NSNumber numberWithInteger:y]    stringValue]];
+    
+	return tileURLString;
+}
+
+- (float)minZoom
+{
+    return [[self.infoDictionary objectForKey:@"minzoom"] floatValue];
+}
+
+- (float)maxZoom
+{
+    return [[self.infoDictionary objectForKey:@"maxzoom"] floatValue];
+}
+
+- (RMSphericalTrapezium)latitudeLongitudeBoundingBox
+{
+    NSArray *parts = [[self.infoDictionary objectForKey:@"bounds"] componentsSeparatedByString:@","];
+        
+    if ([parts count] == 4)
+    {
+        RMSphericalTrapezium bounds = {
+            .southwest = {
+                .longitude = [[parts objectAtIndex:0] doubleValue],
+                .latitude  = [[parts objectAtIndex:1] doubleValue],
+            },
+            .northeast = {
+                .longitude = [[parts objectAtIndex:2] doubleValue],
+                .latitude  = [[parts objectAtIndex:3] doubleValue],
+            },
+        };
+        
+        return bounds;
+    }
+    
+    return kTileStreamDefaultLatLonBoundingBox;
+}
+
+- (BOOL)coversFullWorld
+{
+    RMSphericalTrapezium ownBounds     = [self latitudeLongitudeBoundingBox];
+    RMSphericalTrapezium defaultBounds = kTileStreamDefaultLatLonBoundingBox;
+    
+    if (ownBounds.southwest.longitude <= defaultBounds.southwest.longitude + 10 && 
+        ownBounds.northeast.longitude >= defaultBounds.northeast.longitude - 10)
+        return YES;
+    
+    return NO;
+}
+
+- (NSString *)uniqueTilecacheKey
+{
+	return [NSString stringWithFormat:@"%@-%@", [self.infoDictionary objectForKey:@"id"], [self.infoDictionary objectForKey:@"version"]];
+}
+
+- (NSString *)shortName
+{
+	return [self.infoDictionary objectForKey:@"name"];
+}
+
+- (NSString *)longDescription
+{
+	return [self.infoDictionary objectForKey:@"description"];
+}
+
+- (NSString *)shortAttribution
+{
+	return [self.infoDictionary objectForKey:@"attribution"];
+}
+
+- (NSString *)longAttribution
+{
+	return [self shortAttribution];
+}
+
+- (RMTileStreamLayerType)layerType
+{
+    return ([[self.infoDictionary objectForKey:@"type"] isEqualToString:@"overlay"] ? RMTileStreamLayerTypeOverlay : RMTileStreamLayerTypeBaselayer);
+}
+
+@end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -210,6 +210,8 @@
 		DD55FD1612FB40E000B6FE24 /* RMMBTilesTileSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DD55FD1212FB40E000B6FE24 /* RMMBTilesTileSource.m */; };
 		DDA3E85613B00D9E004D861C /* RMMapQuestOSMSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DDA3E85413B00D9E004D861C /* RMMapQuestOSMSource.h */; };
 		DDA3E85713B00D9E004D861C /* RMMapQuestOSMSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */; };
+		DDCD58D31406F8A400F59E0D /* RMTileStreamSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */; };
+		DDCD58D41406F8A400F59E0D /* RMTileStreamSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */; };
 		F5C12D2A0F8A86CA00A894D2 /* RMGeoHash.h in Headers */ = {isa = PBXBuildFile; fileRef = F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */; };
 		F5C12D2B0F8A86CA00A894D2 /* RMGeoHash.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */; };
 /* End PBXBuildFile section */
@@ -401,6 +403,8 @@
 		DD55FD1312FB40E000B6FE24 /* RMMBTilesTileSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMMBTilesTileSource.h; sourceTree = "<group>"; };
 		DDA3E85413B00D9E004D861C /* RMMapQuestOSMSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMMapQuestOSMSource.h; sourceTree = "<group>"; };
 		DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMMapQuestOSMSource.m; sourceTree = "<group>"; };
+		DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileStreamSource.h; sourceTree = "<group>"; };
+		DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMTileStreamSource.m; sourceTree = "<group>"; };
 		F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMGeoHash.h; sourceTree = "<group>"; };
 		F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMGeoHash.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -700,6 +704,8 @@
 				447420D91302B2F5004D6E8A /* RMWMSSource.m */,
 				DDA3E85413B00D9E004D861C /* RMMapQuestOSMSource.h */,
 				DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */,
+				DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */,
+				DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */,
 			);
 			name = "Tile Source";
 			sourceTree = "<group>";
@@ -891,6 +897,7 @@
 				17F02BB11319BA4B00260C6B /* RouteMe.h in Headers */,
 				175701DE1323C2E900A5D314 /* NSUserDefaults+RouteMe.h in Headers */,
 				DDA3E85613B00D9E004D861C /* RMMapQuestOSMSource.h in Headers */,
+				DDCD58D31406F8A400F59E0D /* RMTileStreamSource.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1193,6 +1200,7 @@
 				4474211C1302B60A004D6E8A /* RMWMS.m in Sources */,
 				175701DF1323C2E900A5D314 /* NSUserDefaults+RouteMe.m in Sources */,
 				DDA3E85713B00D9E004D861C /* RMMapQuestOSMSource.m in Sources */,
+				DDCD58D41406F8A400F59E0D /* RMTileStreamSource.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
These commits add support for TileStream-hosted web tile sources to route-me. The header has a bit more info, but basically, you can get info about tiles hosted on a TileStream instance via its API, then initialize a small dictionary with that info, create an `RMTileStreamSource` tile source, and use that with route-me, similar to other web-hosted tile sources. 
