### PR TITLE
embedded interactivity tile sources

### DIFF
--- a/MapView/Map/JSONKit/CHANGELOG.md
+++ b/MapView/Map/JSONKit/CHANGELOG.md
@@ -1,0 +1,389 @@
+# JSONKit Changelog
+
+## Version 1.X ????/??/??
+
+**IMPORTANT:** The following changelog notes are a work in progress.  They apply to the work done on JSONKit post v1.4.  Since JSONKit itself is inbetween versions, these changelog notes are subject to change, may be wrong, and just about everything else you could expect at this point in development.
+
+### New Features
+
+*    When `JKSerializeOptionPretty` is enabled, JSONKit now sorts the keys.
+
+*    Normally, JSONKit can only serialize NSNull, NSNumber, NSString, NSArray, and NSDictioonary like objects.  It is now possible to serialize an object of any class via either a delegate or a `^` block.
+    
+    The delegate or `^` block must return an object that can be serialized by JSONKit, however, otherwise JSONKit will fail to serialize the object.  In other words, JSONKit tries to serialize an unsupported class of the object just once, and if the delegate or ^block returns another unsupported class, the second attempt to serialize will fail.  In practice, this is not a problem at all, but it does prevent endless recursive attempts to serialize an unsupported class.
+    
+    This makes it trivial to serialize objects like NSDate or NSData.  A NSDate object can be formatted using a NSDateFormatter to return a ISO-8601 `YYYY-MM-DDTHH:MM:SS.sssZ` type object, for example.  Or a NSData object could be Base64 encoded.
+
+    This greatly simplifies things when you have a complex, nested objects with objects that do not belong to the classes that JSONKit can serialize.
+
+    It should be noted that the same caching that JSONKit does for the supported class types also applies to the objects of an unsupported class- if the same object is serialized more than once and the object is still in the serialization cache, JSONKit will copy the previous serialization result instead of invoking the delegate or `^` block again.  Therefore, you should not expect or depend on your delegate or block being called each time the same object needs to be serialized AND the delegate or block MUST return a "formatted object" that is STRICTLY invariant (that is to say the same object must always return the exact same formatted output).
+    
+    To serialize NSArray or NSDictionary objects using a delegate&ndash;
+    
+    **NOTE:** The delegate is based a single argument, the object with the unsupported class, and the supplied `selector` method must be one that accepts a single `id` type argument (i.e., `formatObject:`).  
+    **IMPORTANT:** The `^` block MUST return an object with a class that can be serialized by JSONKit, otherwise the serialization will fail.
+    
+    <pre>
+    &#x200b;- (NSData \*)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError \*\*)error;
+    &#x200b;- (NSString \*)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError \*\*)error;
+    </pre>
+    
+    To serialize NSArray or NSDictionary objects using a `^` block&ndash;
+    
+    **NOTE:** The block is passed a single argument, the object with the unsupported class.  
+    **IMPORTANT:** The `^` block MUST return an object with a class that can be serialized by JSONKit, otherwise the serialization will fail.
+    
+    <pre>
+    &#x200b;- (NSData \*)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(&#x005E;)(id object))block error:(NSError \*\*)error;
+    &#x200b;- (NSString \*)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(&#x005E;)(id object))block error:(NSError \*\*)error;
+    </pre>
+    
+    Example using the delegate way:
+    
+    <pre>
+    @interface MYFormatter : NSObject {
+      NSDateFormatter \*outputFormatter;
+    }
+    @end
+    &#x200b;
+    @implementation MYFormatter
+    -(id)init
+    {
+      if((self = [super init]) == NULL) { return(NULL); }
+      if((outputFormatter = [[NSDateFormatter alloc] init]) == NULL) { [self autorelease]; return(NULL); }
+      [outputFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZ"];
+      return(self);
+    }
+    &#x200b;
+    -(void)dealloc
+    {
+      if(outputFormatter != NULL) { [outputFormatter release]; outputFormatter = NULL; }
+      [super dealloc];
+    }
+    &#x200b;
+    -(id)formatObject:(id)object
+    {
+      if([object isKindOfClass:[NSDate class]]) { return([outputFormatter stringFromDate:object]); }
+      return(NULL);
+    }
+    @end
+    &#x200b;
+    {
+      MYFormatter \*myFormatter = [[[MYFormatter alloc] init] autorelease];
+      NSArray \*array = [NSArray arrayWithObject:[NSDate dateWithTimeIntervalSinceNow:0.0]];
+
+      NSString \*jsonString = NULL;
+      jsonString = [array                    JSONStringWithOptions:JKSerializeOptionNone
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serializeUnsupportedClassesUsingDelegate:myFormatter
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;selector:@selector(formatObject:)
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;error:NULL];
+      NSLog(@"jsonString: '%@'", jsonString);
+      // 2011-03-25 11:42:16.175 formatter_example[59120:903] jsonString: '["2011-03-25T11:42:16.175-0400"]'
+    }
+    </pre>
+    
+    Example using the `^` block way:
+    
+    <pre>
+    {
+      NSDateFormatter \*outputFormatter = [[[NSDateFormatter alloc] init] autorelease];
+      [outputFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZ"];
+      &#x200b;
+      jsonString = [array                 JSONStringWithOptions:encodeOptions
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serializeUnsupportedClassesUsingBlock:&#x005E;id(id object) {
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if([object isKindOfClass:[NSDate class]]) { return([outputFormatter stringFromDate:object]); }
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return(NULL);
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;error:NULL];
+      NSLog(@"jsonString: '%@'", jsonString);
+      // 2011-03-25 11:49:56.434 json_parse[59167:903] jsonString: '["2011-03-25T11:49:56.434-0400"]'
+    }
+    </pre>
+
+### Major Changes
+
+*   The way that JSONKit implements the collection classes was modified.  Specifically, JSONKit now follows the same strategy that the Cocoa collection classes use, which is to have a single subclass of the mutable collection class.  This concrete subclass has an ivar bit that determines whether or not that instance is mutable, and when an immutable instance receives a mutating message, it throws an exception.
+
+## Version 1.4 2011/23/03
+
+### Highlights
+
+*   JSONKit v1.4 significantly improves the performance of serializing and deserializing.  Deserializing is 23% faster than Apples binary `.plist`, and an amazing 549% faster than Apples binary `.plist` when serializing.
+
+### New Features
+
+*   JSONKit can now return mutable collection classes.
+*   The `JKSerializeOptionFlags` option `JKSerializeOptionPretty` was implemented.
+*   It is now possible to serialize a single [`NSString`][NSString].  This functionality was requested in issue #4 and issue #11.
+
+### Deprecated Methods
+
+*   The following `JSONDecoder` methods are deprecated beginning with JSONKit v1.4 and will be removed in a later release&ndash;
+    
+    <pre>
+    &#x200b;- (id)parseUTF8String:(const unsigned char \*)string length:(size_t)length;
+    &#x200b;- (id)parseUTF8String:(const unsigned char \*)string length:(size_t)length error:(NSError \*\*)error;
+    &#x200b;- (id)parseJSONData:(NSData \*)jsonData;
+    &#x200b;- (id)parseJSONData:(NSData \*)jsonData error:(NSError \*\*)error;
+    </pre>
+    
+    The JSONKit v1.4 <code>objectWith&hellip;</code> methods should be used instead.
+
+### NEW API's
+
+*   The following methods were added to `JSONDecoder`&ndash;
+    
+    These methods replace their deprecated <code>parse&hellip;</code> counterparts and return immutable collection objects.
+    
+    <pre>
+    &#x200b;- (id)objectWithUTF8String:(const unsigned char \*)string length:(NSUInteger)length;
+    &#x200b;- (id)objectWithUTF8String:(const unsigned char \*)string length:(NSUInteger)length error:(NSError \*\*)error;
+    &#x200b;- (id)objectWithData:(NSData \*)jsonData;
+    &#x200b;- (id)objectWithData:(NSData \*)jsonData error:(NSError \*\*)error;
+    </pre>
+    
+    These methods are the same as their <code>objectWith&hellip;</code> counterparts except they return mutable collection objects.
+    
+    <pre>
+    &#x200b;- (id)mutableObjectWithUTF8String:(const unsigned char \*)string length:(NSUInteger)length;
+    &#x200b;- (id)mutableObjectWithUTF8String:(const unsigned char \*)string length:(NSUInteger)length error:(NSError \*\*)error;
+    &#x200b;- (id)mutableObjectWithData:(NSData \*)jsonData;
+    &#x200b;- (id)mutableObjectWithData:(NSData \*)jsonData error:(NSError \*\*)error;
+    </pre>
+
+*   The following methods were added to `NSString (JSONKitDeserializing)`&ndash;
+    
+    These methods are the same as their <code>objectFrom&hellip;</code> counterparts except they return mutable collection objects.
+    
+    <pre>
+    &#x200b;- (id)mutableObjectFromJSONString;
+    &#x200b;- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+    &#x200b;- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError \*\*)error;
+    </pre>
+
+*   The following methods were added to `NSData (JSONKitDeserializing)`&ndash;
+    
+    These methods are the same as their <code>objectFrom&hellip;</code> counterparts except they return mutable collection objects.
+    
+    <pre>
+    &#x200b;- (id)mutableObjectFromJSONData;
+    &#x200b;- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+    &#x200b;- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError \*\*)error;
+    </pre>
+
+*   The following methods were added to `NSString (JSONKitSerializing)`&ndash;
+    
+    These methods are for those uses that need to serialize a single [`NSString`][NSString]&ndash;
+    
+    <pre>
+    &#x200b;- (NSData \*)JSONData;
+    &#x200b;- (NSData \*)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError \*\*)error;
+    &#x200b;- (NSString \*)JSONString;
+    &#x200b;- (NSString \*)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError \*\*)error;
+    </pre>
+    
+### Bug Fixes
+
+*   JSONKit has a fast and a slow path for parsing JSON Strings.  The slow path is needed whenever special string processing is required, such as the conversion of `\` escape sequences or ill-formed UTF-8.  Although the slow path had a check for characters < `0x20`, which are not permitted by the [RFC 4627][], there was a bug such that the condition was never actually checked.  As a result, JSONKit would have incorrectly accepted JSON that contained characters < `0x20` if it was using the slow path to process a JSON String.
+*   The low surrogate in a <code>\u<i><b>high</b></i>\u<i><b>low</b></i></code> escape sequence in a JSON String was incorrectly treating `dfff` as ill-formed Unicode.  This was due to a comparison that used `>= 0xdfff` instead of `> 0xdfff` as it should have.
+*   `JKParseOptionLooseUnicode` was not properly honored when parsing some types of ill-formed Unicode in <code>\u<i><b>HHHH</b></i></code> escapes in JSON Strings.
+
+### Important Notes
+    
+*   JSONKit v1.4 now uses custom concrete subclasses of [`NSArray`][NSArray], [`NSMutableArray`][NSMutableArray], [`NSDictionary`][NSDictionary], and [`NSMutableDictionary`][NSMutableDictionary]&mdash; `JKArray`, `JKMutableArray`, `JKDictionary`, and `JKMutableDictionary`. respectively.  These classes are internal and private to JSONKit, you should not instantiate objects from these classes directly.
+
+    In theory, these custom classes should behave exactly the same as the respective Foundation / Cocoa counterparts.
+    
+    As usual, in practice may have non-linear excursions from what theory predicts.  It is also virtually impossible to properly test or predict how these custom classes will interact with software in the wild.
+    
+    Most likely, if you do encounter a problem, it will happen very quickly, and you should report a bug via the [github.com JSONKit Issue Tracker][bugtracker].
+    
+    In addition to the required class cluster primitive methods, the custom collection classes also include support for [`NSFastEnumeration`][NSFastEnumeration], along with methods that support the bulk retrieval of the objects contents.
+    
+    #### Exceptions Thrown
+    
+    The JSONKit collection classes will throw the same exceptions for the same conditions as their respective Foundation counterparts.  If you find a discrepancy, please report a bug via the [github.com JSONKit Issue Tracker][bugtracker].
+    
+    #### Multithreading Safety
+    
+    The same multithreading rules and caveats for the Foundation collection classes apply to the JSONKit collection classes.  Specifically, it should be safe to use the immutable collections from multiple threads concurrently.
+    
+    The mutable collections can be used from multiple threads as long as you provide some form of mutex barrier that ensures that if a thread needs to mutate the collection, then it has exclusive access to the collection&ndash; no other thread can be reading from or writing to the collection until the mutating thread has finished.  Failure to ensure that there are no other threads reading or writing from the mutable collection when a thread mutates the collection will result in `undefined` behavior.
+    
+    #### Mutable Collection Notes
+    
+    The mutable versions of the collection classes are meant to be used when you need to make minor modifications to the collection.  Neither `JKMutableArray` or `JKMutableDictionary` have been optimized for nor are they intended to be used in situations where you are adding a large number of objects or new keys&ndash; these types of operations will cause both classes to frequently reallocate the memory used to hold the objects in the collection.
+    
+    #### `JKMutableArray` Usage Notes
+    
+    * You should minimize the number of new objects you added to the array.  The array is not designed for high performance insertion and removal of objects.  If the array does not have any extra capacity it must reallocate the backing store.  When the array is forced to grow the backing store, it currently adds an additional 16 slots worth of spare capacity.  The array is instantiated without any extra capacity on the assumption that dictionaries are going to be mutated more than arrays.  The array never shrinks the backing store.
+    
+    * Replacing objects in the array via [`-replaceObjectAtIndex:withObject:`][-replaceObjectAtIndex:withObject:] is very fast since the array simply releases the current object at the index and replaces it with the new object.
+    
+    * Inserting an object in to the array via [`-insertObject:atIndex:`][-insertObject:atIndex:] cause the array to [`memmove()`][memmove] all the objects up one slot from the insertion index.  This means this operation is fastest when inserting objects at the last index since no objects need to be moved.
+    
+    * Removing an object from the array via [`-removeObjectAtIndex:`][-removeObjectAtIndex:] causes the array to [`memmove()`][memmove] all the objects down one slot from the removal index.  This means this operation is fastest when removing objects at the last index since no objects need to be moved.  The array will not resize its backing store to a smaller size.
+    
+    * [`-copy`][-copy] and [`-mutableCopy`][-mutableCopy] will instantiate a new [`NSArray`][NSArray] or [`NSMutableArray`][NSMutableArray] class object, respectively, with the contents of the receiver.
+    
+    #### `JKMutableDictionary` Usage Notes
+    
+    * You should minimize the number of new keys you add to the dictionary.  If the number of items in the dictionary exceeds a threshold value it will trigger a resizing operation.  To do this, the dictionary must allocate a new, larger backing store, and then re-add all the items in the dictionary by rehashing them to the size of the newer, larger store.  This is an expensive operation.  While this is a limitation of nearly all hash tables, the capacity for the hash table used by `JKMutableDictionary` has been chosen to minimize the amount of memory used since it is anticipated that most dictionaries will not grow significantly once they are instantiated.
+    
+    * If the key already exists in the dictionary and you change the object associated with it via [`-setObject:forKey:`][-setObject:forKey:], this will not cause any performance problems or trigger a hash table resize.
+    
+    * Removing a key from the dictionary via [`-removeObjectForKey:`][-removeObjectForKey:] will not cause any performance problems.  However, the dictionary will not resize its backing store to the smaller size.
+    
+    * [`-copy`][-copy] and [`-mutableCopy`][-mutableCopy] will instantiate a new [`NSDictionary`][NSDictionary] or [`NSMutableDictionary`][NSMutableDictionary] class object, respectively, with the contents of the receiver.
+
+### Major Changes
+
+*   The `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` pre-processor define flag that was added to JSONKit v1.3 has been removed.
+    
+    `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` was added in JSONKit v1.3 as a temporary work around.  While the author was aware of other ways to fix the particular problem caused by the usage of "transfer of ownership callbacks" with Core Foundation classes, the fix provided in JSONKit v1.3 was trivial to implement.  This allowed people who needed that functionality to use JSONKit while a proper solution to the problem was worked on.  JSONKit v1.4 is the result of that work.
+    
+    JSONKit v1.4 no longer uses the Core Foundation collection classes [`CFArray`][CFArray] and [`CFDictionary`][CFDictionary].  Instead, JSONKit v1.4 contains a concrete subclass of [`NSArray`][NSArray] and [`NSDictionary`][NSDictionary]&ndash; `JKArray` and `JKDictionary`, respectively.  As a result, JSONKit has complete control over the behavior of how items are added and managed within an instantiated collection object.  The `JKArray` and `JKDictionary` classes are private to JSONKit, you should not instantiate them direction.  Since they are concrete subclasses of their respective collection class cluster, they behave and act exactly the same as [`NSArray`][NSArray] and [`NSDictionary`][NSDictionary].
+    
+    The first benefit is that the "transfer of ownership" object ownership policy can now be safely used.  Because the JSONKit collection objects understand that some methods, such as [`-mutableCopy`][-mutableCopy], should not inherit the same "transfer of ownership" object ownership policy, but must follow the standard Cocoa object ownership policy.  The "transfer of ownership" object ownership policy reduces the number of [`-retain`][-retain] and [`-release`][-release] calls needed to add an object to a collection, and when creating a large number of objects very quickly (as you would expect when parsing JSON), this can result in a non-trivial amount of time.  Eliminating these calls means faster JSON parsing.
+    
+    A second benefit is that the author encountered some unexpected behavior when using the [`CFDictionaryCreate`][CFDictionaryCreate] function to create a dictionary and the `keys` argument contained duplicate keys.  This required JSONKit to de-duplicate the keys and values before calling [`CFDictionaryCreate`][CFDictionaryCreate].  Unfortunately, JSONKit always had to scan all the keys to make sure there were no duplicates, even though 99.99% of the time there were none.  This was less than optimal, particularly because one of the solutions to this particular problem is to use a hash table to perform the de-duplication.  Now JSONKit can do the de-duplication while it is instantiating the dictionary collection, solving two problems at once.
+    
+    Yet another benefit is that the recently instantiated object cache that JSONKit uses can be used to cache information about the keys used to create dictionary collections, in particular a keys [`-hash`][-hash] value.  For a lot of real world JSON, this effectively means that the [`-hash`][-hash] for a key is calculated once, and that value is reused again and again when creating dictionaries.  Because all the information required to create the hash table used by `JKDictionary` is already determined at the time the `JKDictionary` object is instantiated, populating the `JKDictionary` is now a very tight loop that only has to call [`-isEqual:`][-isEqual:] on the rare occasions that the JSON being parsed contains duplicate keys.  Since the functions that handle this logic are all declared `static` and are internal to JSONKit, the compiler can heavily optimize this code.
+    
+    What does this mean in terms of performance?  JSONKit was already fast, but now, it's even faster.  Below is some benchmark times for [`twitter_public_timeline.json`][twitter_public_timeline.json] in [samsoffes / json-benchmarks](https://github.com/samsoffes/json-benchmarks), where _read_ means to convert the JSON to native Objective-C objects, and _write_ means to convert the native Objective-C to JSON&mdash;
+    
+    <pre>
+    v1.3 read : min:  456.000 us, avg:  460.056 us, char/s:  53341332.36 /  50.870 MB/s
+    v1.3 write: min:  150.000 us, avg:  151.816 us, char/s: 161643041.58 / 154.155 MB/s</pre>
+    
+    <pre>
+    v1.4 read : min:  285.000 us, avg:  288.603 us, char/s:  85030301.14 /  81.091 MB/s
+    v1.4 write: min:  127.000 us, avg:  129.617 us, char/s: 189327017.29 / 180.556 MB/s</pre>
+    
+    JSONKit v1.4 is nearly 60% faster at reading and 17% faster at writing than v1.3.
+    
+    The following is the JSON test file taken from the project available at [this blog post](http://psionides.jogger.pl/2010/12/12/cocoa-json-parsing-libraries-part-2/).  The keys and information contained in the JSON was anonymized with random characters.  Since JSONKit relies on its recently instantiated object cache for a lot of its performance, this JSON happens to be "the worst corner case possible".
+    
+    <pre>
+    v1.3 read : min: 5222.000 us, avg: 5262.344 us, char/s:  15585260.10 /  14.863 MB/s
+    v1.3 write: min: 1253.000 us, avg: 1259.914 us, char/s:  65095712.88 /  62.080 MB/s</pre>
+    
+    <pre>
+    v1.4 read : min: 4096.000 us, avg: 4122.240 us, char/s:  19895736.30 /  18.974 MB/s
+    v1.4 write: min: 1319.000 us, avg: 1335.538 us, char/s:  61409709.05 /  58.565 MB/s</pre>
+    
+    JSONKit v1.4 is 28% faster at reading and 6% faster at writing that v1.3 in this worst-case torture test.
+    
+    While your milage may vary, you will likely see improvements in the 50% for reading and 10% for writing on your real world JSON.  The nature of JSONKits cache means performance improvements is statistical in nature and depends on the particular properties of the JSON being parsed.
+    
+    For comparison, [json-framework][], a popular Objective-C JSON parsing library, turns in the following benchmark times for [`twitter_public_timeline.json`][twitter_public_timeline.json]&mdash;
+    
+    <pre>
+    &#x200b;     read : min: 1670.000 us, avg: 1682.461 us, char/s:  14585776.43 /  13.910 MB/s
+    &#x200b;     write: min: 1021.000 us, avg: 1028.970 us, char/s:  23849091.81 /  22.744 MB/s</pre>
+    
+    Since the benchmark for JSONKit and [json-framework][] was done on the same computer, it's safe to compare the timing results.  The version of [json-framework][] used was the latest v3.0 available via the master branch at the time of this writing on github.com.
+    
+    JSONKit v1.4 is 483% faster at reading and 694% faster at writing than [json-framework][].
+
+### Other Changes
+
+*   Added a `__clang_analyzer__` pre-processor conditional around some code that the `clang` static analyzer was giving false positives for.  However, `clang` versions &le; 1.5 do not define `__clang_analyzer__` and therefore will continue to emit analyzer warnings.
+*   The cache now uses a Galois Linear Feedback Shift Register PRNG to select which item in the cache to randomly age.  This should age items in the cache more fairly.
+*   To promote better L1 cache locality, the cache age structure was rearranged slightly along with modifying when an item is randomly chosen to be aged.
+*   Removed a lot of internal and private data structures from `JSONKit.h` and put them in `JSONKit.m`.
+*   Modified the way floating point values are serialized.  Previously, the [`printf`][printf] format conversion `%.16g` was used.  This was changed to `%.17g` which should theoretically allow for up to a full `float`, or [IEEE 754 Single 32-bit floating-point][Single Precision], of precision when converting floating point values to decimal representation. 
+*   The usual sundry of inconsequential tidies and what not, such as updating the `README.md`, etc.
+*   The catagory additions to the Cocoa classes were changed from `JSONKit` to `JSONKitDeserializing` and `JSONKitSerializing`, as appropriate.
+
+## Version 1.3 2011/05/02
+
+### New Features
+
+*   Added the `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` pre-processor define flag.
+    
+    This is typically enabled by adding `-DJK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` to the compilers command line arguments or in `Xcode.app` by adding `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` to a projects / targets `Pre-Processor Macros` settings.
+    
+    The `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` option enables the use of custom Core Foundation collection call backs which omit the [`CFRetain`][CFRetain] calls.  This results in saving several [`CFRetain`][CFRetain] and [`CFRelease`][CFRelease] calls typically needed for every single object from the parsed JSON.  While the author has used this technique for years without any issues, an unexpected interaction with the Foundation [`-mutableCopy`][-mutableCopy] method and Core Foundation Toll-Free Bridging resulting in a condition in which the objects contained in the collection to be over released.  This problem does not occur with the use of [`-copy`][-copy] due to the fact that the objects created by JSONKit are immutable, and therefore [`-copy`][-copy] does not require creating a completely new object and copying the contents, instead [`-copy`][-copy] simply returns a [`-retain`][-retain]'d version of the immutable object which is significantly faster along with the obvious reduction in memory usage.
+    
+    Prior to version 1.3, JSONKit always used custom "Transfer of Ownership Collection Callbacks", and thus `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` was effectively implicitly defined.
+    
+    Beginning with version 1.3, the default behavior of JSONKit is to use the standard Core Foundation collection callbacks ([`kCFTypeArrayCallBacks`][kCFTypeArrayCallBacks], [`kCFTypeDictionaryKeyCallBacks`][kCFTypeDictionaryKeyCallBacks], and [`kCFTypeDictionaryValueCallBacks`][kCFTypeDictionaryValueCallBacks]).  The intention is to follow "the principle of least surprise", and the author believes the use of the standard Core Foundation collection callbacks as the default behavior for JSONKit results in the least surprise.
+    
+    **NOTE**: `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` is only applicable to `(CF|NS)` `Dictionary` and `Array` class objects.
+    
+    For the vast majority of users, the author believes JSONKits custom "Transfer of Ownership Collection Callbacks" will not cause any problems.  As previously stated, the author has used this technique in performance critical code for years and has never had a problem.  Until a user reported a problem with [`-mutableCopy`][-mutableCopy], the author was unaware that the use of the custom callbacks could even cause a problem.  This is probably due to the fact that the vast majority of time the typical usage pattern tends to be "iterate the contents of the collection" and very rarely mutate the returned collection directly (although this last part is likely to vary significantly from programmer to programmer).  The author tends to avoid the use of [`-mutableCopy`][-mutableCopy] as it results in a significant performance and memory consumption penalty.  The reason for this is in "typical" Cocoa coding patterns, using [`-mutableCopy`][-mutableCopy] will instantiate an identical, albeit mutable, version of the original object.  This requires both memory for the new object and time to iterate the contents of the original object and add them to the new object.  Furthermore, under "typical" Cocoa coding patterns, the original collection object continues to consume memory until the autorelease pool is released.  However, clearly there are cases where the use of [`-mutableCopy`][-mutableCopy] makes sense or may be used by an external library which is out of your direct control.
+    
+    The use of the standard Core Foundation collection callbacks results in a 9% to 23% reduction in parsing performance, with an "eye-balled average" of around 13% according to some benchmarking done by the author using Real World&trade; JSON (i.e., actual JSON from various web services, such as Twitter, etc) using `gcc-4.2 -arch x86_64 -O3 -DNS_BLOCK_ASSERTIONS` with the only change being the addition of `-DJK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS`.
+    
+    `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS` is only applicable to parsing / deserializing (i.e. converting from) of JSON.  Serializing (i.e., converting to JSON) is completely unaffected by this change.
+
+### Bug Fixes
+
+*   Fixed a [bug report regarding `-mutableCopy`](https://github.com/johnezang/JSONKit/issues#issue/3).  This is related to the addition of the pre-processor define flag `JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS`.
+
+### Other Changes
+
+*   Added `JK_EXPECTED` optimization hints around several conditionals.
+*   When serializing objects, JSONKit first starts with a small, on stack buffer.  If the encoded JSON exceeds the size of the stack buffer, JSONKit switches to a heap allocated buffer.  If JSONKit switched to a heap allocated buffer, [`CFDataCreateWithBytesNoCopy`][CFDataCreateWithBytesNoCopy] is used to create the [`NSData`][NSData] object, which in most cases causes the heap allocated buffer to "transfer" to the [`NSData`][NSData] object which is substantially faster than allocating a new buffer and copying the bytes.
+*   Added a pre-processor check in `JSONKit.m` to see if Objective-C Garbage Collection is enabled and issue a `#error` notice that JSONKit does not support Objective-C Garbage Collection.
+*   Various other minor or trivial modifications, such as updating `README.md`.
+
+### Other Issues
+
+*   When using the `clang` static analyzer (the version used at the time of this writing was `Apple clang version 1.5 (tags/Apple/clang-60)`), the static analyzer reports a number of problems with `JSONKit.m`.
+    
+    The author has investigated these issues and determined that the problems reported by the current version of the static analyzer are "false positives".  Not only that, the reported problems are not only "false positives", they are very clearly and obviously wrong.  Therefore, the author has made the decision that no action will be taken on these non-problems, which includes not modifying the code for the sole purpose of silencing the static analyzer.  The justification for this is "the dog wags the tail, not the other way around."
+
+## Version 1.2 2011/01/08
+
+### Bug Fixes
+
+*   When JSONKit attempted to parse and decode JSON that contained `{"key": value}` dictionaries that contained the same key more than once would likely result in a crash.  This was a serious bug.
+*   Under some conditions, JSONKit could potentially leak memory.
+*   There was an off by one error in the code that checked whether or not the parser was at the end of the `UTF8` buffer.  This could result in JSONKit reading one by past the buffer bounds in some cases.
+
+### Other Changes
+
+*   Some of the methods were missing `NULL` pointer checks for some of their arguments.  This was fixed.  In generally, when JSONKit encounters invalid arguments, it throws a `NSInvalidArgumentException` exception.
+*   Various other minor changes such as tightening up numeric literals with `UL` or `L` qualification, assertion check tweaks and additions, etc.
+*   The README.md file was updated with additional information.
+
+### Version 1.1
+
+No change log information was kept for versions prior to 1.2.
+
+[bugtracker]: https://github.com/johnezang/JSONKit/issues
+[RFC 4627]: http://tools.ietf.org/html/rfc4627
+[twitter_public_timeline.json]: https://github.com/samsoffes/json-benchmarks/blob/master/Resources/twitter_public_timeline.json
+[json-framework]: https://github.com/stig/json-framework
+[Single Precision]: http://en.wikipedia.org/wiki/Single_precision
+[kCFTypeArrayCallBacks]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFArrayRef/Reference/reference.html#//apple_ref/c/data/kCFTypeArrayCallBacks
+[kCFTypeDictionaryKeyCallBacks]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFDictionaryRef/Reference/reference.html#//apple_ref/c/data/kCFTypeDictionaryKeyCallBacks
+[kCFTypeDictionaryValueCallBacks]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFDictionaryRef/Reference/reference.html#//apple_ref/c/data/kCFTypeDictionaryValueCallBacks
+[CFRetain]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFTypeRef/Reference/reference.html#//apple_ref/c/func/CFRetain
+[CFRelease]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFTypeRef/Reference/reference.html#//apple_ref/c/func/CFRelease
+[CFDataCreateWithBytesNoCopy]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFDataRef/Reference/reference.html#//apple_ref/c/func/CFDataCreateWithBytesNoCopy
+[CFArray]: http://developer.apple.com/library/mac/#documentation/CoreFoundation/Reference/CFArrayRef/Reference/reference.html
+[CFDictionary]: http://developer.apple.com/library/mac/#documentation/CoreFoundation/Reference/CFDictionaryRef/Reference/reference.html
+[CFDictionaryCreate]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFDictionaryRef/Reference/reference.html#//apple_ref/c/func/CFDictionaryCreate
+[-mutableCopy]: http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSObject_Class/Reference/Reference.html%23//apple_ref/occ/instm/NSObject/mutableCopy
+[-copy]: http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSObject_Class/Reference/Reference.html%23//apple_ref/occ/instm/NSObject/copy
+[-retain]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Protocols/NSObject_Protocol/Reference/NSObject.html#//apple_ref/occ/intfm/NSObject/retain
+[-release]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Protocols/NSObject_Protocol/Reference/NSObject.html#//apple_ref/occ/intfm/NSObject/release
+[-isEqual:]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Protocols/NSObject_Protocol/Reference/NSObject.html#//apple_ref/occ/intfm/NSObject/isEqual:
+[-hash]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Protocols/NSObject_Protocol/Reference/NSObject.html#//apple_ref/occ/intfm/NSObject/hash
+[NSArray]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSArray_Class/index.html
+[NSMutableArray]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSMutableArray_Class/index.html
+[-insertObject:atIndex:]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSMutableArray_Class/Reference/Reference.html#//apple_ref/occ/instm/NSMutableArray/insertObject:atIndex:
+[-removeObjectAtIndex:]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSMutableArray_Class/Reference/Reference.html#//apple_ref/occ/instm/NSMutableArray/removeObjectAtIndex:
+[-replaceObjectAtIndex:withObject:]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSMutableArray_Class/Reference/Reference.html#//apple_ref/occ/instm/NSMutableArray/replaceObjectAtIndex:withObject:
+[NSDictionary]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSDictionary_Class/index.html
+[NSMutableDictionary]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSMutableDictionary_Class/index.html
+[-setObject:forKey:]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSMutableDictionary_Class/Reference/Reference.html#//apple_ref/occ/instm/NSMutableDictionary/setObject:forKey:
+[-removeObjectForKey:]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSMutableDictionary_Class/Reference/Reference.html#//apple_ref/occ/instm/NSMutableDictionary/removeObjectForKey:
+[NSData]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/index.html
+[NSFastEnumeration]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/NSFastEnumeration_protocol/Reference/NSFastEnumeration.html
+[NSString]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/index.html
+[printf]: http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/printf.3.html
+[memmove]: http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/memmove.3.html

--- a/MapView/Map/JSONKit/JSONKit.h
+++ b/MapView/Map/JSONKit/JSONKit.h
@@ -1,0 +1,251 @@
+//
+//  JSONKit.h
+//  http://github.com/johnezang/JSONKit
+//  Dual licensed under either the terms of the BSD License, or alternatively
+//  under the terms of the Apache License, Version 2.0, as specified below.
+//
+
+/*
+ Copyright (c) 2011, John Engelhart
+ 
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ 
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ 
+ * Neither the name of the Zang Industries nor the names of its
+ contributors may be used to endorse or promote products derived from
+ this software without specific prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ Copyright 2011 John Engelhart
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <limits.h>
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
+
+#ifdef    __OBJC__
+#import <Foundation/NSArray.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSError.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSString.h>
+#endif // __OBJC__
+ 
+#ifdef __cplusplus
+extern "C" {
+#endif
+  
+
+// For Mac OS X < 10.5.
+#ifndef   NSINTEGER_DEFINED
+#define   NSINTEGER_DEFINED
+#if       defined(__LP64__) || defined(NS_BUILD_32_LIKE_64)
+typedef long           NSInteger;
+typedef unsigned long  NSUInteger;
+#define NSIntegerMin   LONG_MIN
+#define NSIntegerMax   LONG_MAX
+#define NSUIntegerMax  ULONG_MAX
+#else  // defined(__LP64__) || defined(NS_BUILD_32_LIKE_64)
+typedef int            NSInteger;
+typedef unsigned int   NSUInteger;
+#define NSIntegerMin   INT_MIN
+#define NSIntegerMax   INT_MAX
+#define NSUIntegerMax  UINT_MAX
+#endif // defined(__LP64__) || defined(NS_BUILD_32_LIKE_64)
+#endif // NSINTEGER_DEFINED
+
+
+#ifndef _JSONKIT_H_
+#define _JSONKIT_H_
+
+#if defined(__GNUC__) && (__GNUC__ >= 4) && defined(__APPLE_CC__) && (__APPLE_CC__ >= 5465)
+#define JK_DEPRECATED_ATTRIBUTE __attribute__((deprecated))
+#else
+#define JK_DEPRECATED_ATTRIBUTE
+#endif
+  
+#define JSONKIT_VERSION_MAJOR 1
+#define JSONKIT_VERSION_MINOR 4
+
+typedef NSUInteger JKFlags;
+
+/*
+  JKParseOptionComments        : Allow C style // and /_* ... *_/ (without a _, obviously) comments in JSON.
+  JKParseOptionUnicodeNewlines : Allow Unicode recommended (?:\r\n|[\n\v\f\r\x85\p{Zl}\p{Zp}]) newlines.
+  JKParseOptionLooseUnicode    : Normally the decoder will stop with an error at any malformed Unicode.
+                                 This option allows JSON with malformed Unicode to be parsed without reporting an error.
+                                 Any malformed Unicode is replaced with \uFFFD, or "REPLACEMENT CHARACTER".
+ */
+
+enum {
+  JKParseOptionNone                     = 0,
+  JKParseOptionStrict                   = 0,
+  JKParseOptionComments                 = (1 << 0),
+  JKParseOptionUnicodeNewlines          = (1 << 1),
+  JKParseOptionLooseUnicode             = (1 << 2),
+  JKParseOptionPermitTextAfterValidJSON = (1 << 3),
+  JKParseOptionValidFlags               = (JKParseOptionComments | JKParseOptionUnicodeNewlines | JKParseOptionLooseUnicode | JKParseOptionPermitTextAfterValidJSON),
+};
+typedef JKFlags JKParseOptionFlags;
+
+enum {
+  JKSerializeOptionNone                 = 0,
+  JKSerializeOptionPretty               = (1 << 0),
+  JKSerializeOptionEscapeUnicode        = (1 << 1),
+  JKSerializeOptionEscapeForwardSlashes = (1 << 4),
+  JKSerializeOptionValidFlags           = (JKSerializeOptionPretty | JKSerializeOptionEscapeUnicode | JKSerializeOptionEscapeForwardSlashes),
+};
+typedef JKFlags JKSerializeOptionFlags;
+
+#ifdef    __OBJC__
+
+typedef struct JKParseState JKParseState; // Opaque internal, private type.
+
+// As a general rule of thumb, if you use a method that doesn't accept a JKParseOptionFlags argument, it defaults to JKParseOptionStrict
+
+@interface JSONDecoder : NSObject {
+  JKParseState *parseState;
+}
++ (id)decoder;
++ (id)decoderWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)initWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (void)clearCache;
+
+// The parse... methods were deprecated in v1.4 in favor of the v1.4 objectWith... methods.
+- (id)parseUTF8String:(const unsigned char *)string length:(size_t)length                         JK_DEPRECATED_ATTRIBUTE; // Deprecated in JSONKit v1.4.  Use objectWithUTF8String:length:        instead.
+- (id)parseUTF8String:(const unsigned char *)string length:(size_t)length error:(NSError **)error JK_DEPRECATED_ATTRIBUTE; // Deprecated in JSONKit v1.4.  Use objectWithUTF8String:length:error:  instead.
+// The NSData MUST be UTF8 encoded JSON.
+- (id)parseJSONData:(NSData *)jsonData                                                            JK_DEPRECATED_ATTRIBUTE; // Deprecated in JSONKit v1.4.  Use objectWithData:                     instead.
+- (id)parseJSONData:(NSData *)jsonData error:(NSError **)error                                    JK_DEPRECATED_ATTRIBUTE; // Deprecated in JSONKit v1.4.  Use objectWithData:error:               instead.
+
+// Methods that return immutable collection objects.
+- (id)objectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length;
+- (id)objectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length error:(NSError **)error;
+// The NSData MUST be UTF8 encoded JSON.
+- (id)objectWithData:(NSData *)jsonData;
+- (id)objectWithData:(NSData *)jsonData error:(NSError **)error;
+
+// Methods that return mutable collection objects.
+- (id)mutableObjectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length;
+- (id)mutableObjectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length error:(NSError **)error;
+// The NSData MUST be UTF8 encoded JSON.
+- (id)mutableObjectWithData:(NSData *)jsonData;
+- (id)mutableObjectWithData:(NSData *)jsonData error:(NSError **)error;
+
+@end
+
+////////////
+#pragma mark Deserializing methods
+////////////
+
+@interface NSString (JSONKitDeserializing)
+- (id)objectFromJSONString;
+- (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+- (id)mutableObjectFromJSONString;
+- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+@end
+
+@interface NSData (JSONKitDeserializing)
+// The NSData MUST be UTF8 encoded JSON.
+- (id)objectFromJSONData;
+- (id)objectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)objectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+- (id)mutableObjectFromJSONData;
+- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+@end
+
+////////////
+#pragma mark Serializing methods
+////////////
+  
+@interface NSString (JSONKitSerializing)
+// Convenience methods for those that need to serialize the receiving NSString (i.e., instead of having to serialize a NSArray with a single NSString, you can "serialize to JSON" just the NSString).
+// Normally, a string that is serialized to JSON has quotation marks surrounding it, which you may or may not want when serializing a single string, and can be controlled with includeQuotes:
+// includeQuotes:YES `a "test"...` -> `"a \"test\"..."`
+// includeQuotes:NO  `a "test"...` -> `a \"test\"...`
+- (NSData *)JSONData;     // Invokes JSONDataWithOptions:JKSerializeOptionNone   includeQuotes:YES
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError **)error;
+- (NSString *)JSONString; // Invokes JSONStringWithOptions:JKSerializeOptionNone includeQuotes:YES
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError **)error;
+@end
+
+@interface NSArray (JSONKitSerializing)
+- (NSData *)JSONData;
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error;
+- (NSString *)JSONString;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error;
+@end
+
+@interface NSDictionary (JSONKitSerializing)
+- (NSData *)JSONData;
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error;
+- (NSString *)JSONString;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error;
+@end
+
+#ifdef __BLOCKS__
+
+@interface NSArray (JSONKitSerializingBlockAdditions)
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error;
+@end
+
+@interface NSDictionary (JSONKitSerializingBlockAdditions)
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error;
+@end
+  
+#endif
+
+
+#endif // __OBJC__
+
+#endif // _JSONKIT_H_
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/MapView/Map/JSONKit/JSONKit.m
+++ b/MapView/Map/JSONKit/JSONKit.m
@@ -1,0 +1,3022 @@
+//
+//  JSONKit.m
+//  http://github.com/johnezang/JSONKit
+//  Dual licensed under either the terms of the BSD License, or alternatively
+//  under the terms of the Apache License, Version 2.0, as specified below.
+//
+
+/*
+ Copyright (c) 2011, John Engelhart
+ 
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ 
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ 
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ 
+ * Neither the name of the Zang Industries nor the names of its
+ contributors may be used to endorse or promote products derived from
+ this software without specific prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+ Copyright 2011 John Engelhart
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+
+/*
+  Acknowledgments:
+
+  The bulk of the UTF8 / UTF32 conversion and verification comes
+  from ConvertUTF.[hc].  It has been modified from the original sources.
+
+  The original sources were obtained from http://www.unicode.org/.
+  However, the web site no longer seems to host the files.  Instead,
+  the Unicode FAQ http://www.unicode.org/faq//utf_bom.html#gen4
+  points to International Components for Unicode (ICU)
+  http://site.icu-project.org/ as an example of how to write a UTF
+  converter.
+
+  The decision to use the ConvertUTF.[ch] code was made to leverage
+  "proven" code.  Hopefully the local modifications are bug free.
+
+  The code in isValidCodePoint() is derived from the ICU code in
+  utf.h for the macros U_IS_UNICODE_NONCHAR and U_IS_UNICODE_CHAR.
+
+  From the original ConvertUTF.[ch]:
+
+ * Copyright 2001-2004 Unicode, Inc.
+ * 
+ * Disclaimer
+ * 
+ * This source code is provided as is by Unicode, Inc. No claims are
+ * made as to fitness for any particular purpose. No warranties of any
+ * kind are expressed or implied. The recipient agrees to determine
+ * applicability of information provided. If this file has been
+ * purchased on magnetic or optical media from Unicode, Inc., the
+ * sole remedy for any claim will be exchange of defective media
+ * within 90 days of receipt.
+ * 
+ * Limitations on Rights to Redistribute This Code
+ * 
+ * Unicode, Inc. hereby grants the right to freely use the information
+ * supplied in this file in the creation of products supporting the
+ * Unicode Standard, and to make copies of this file in any form
+ * for internal or external distribution as long as this notice
+ * remains attached.
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/errno.h>
+#include <math.h>
+#include <limits.h>
+#include <objc/runtime.h>
+
+#import "JSONKit.h"
+
+//#include <CoreFoundation/CoreFoundation.h>
+#include <CoreFoundation/CFString.h>
+#include <CoreFoundation/CFArray.h>
+#include <CoreFoundation/CFDictionary.h>
+#include <CoreFoundation/CFNumber.h>
+
+//#import <Foundation/Foundation.h>
+#import <Foundation/NSArray.h>
+#import <Foundation/NSAutoreleasePool.h>
+#import <Foundation/NSData.h>
+#import <Foundation/NSDictionary.h>
+#import <Foundation/NSException.h>
+#import <Foundation/NSNull.h>
+#import <Foundation/NSObjCRuntime.h>
+
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#ifdef JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS
+#warning As of JSONKit v1.4, JK_ENABLE_CF_TRANSFER_OWNERSHIP_CALLBACKS is no longer required.  It is no longer a valid option.
+#endif
+
+#ifdef __OBJC_GC__
+#error JSONKit does not support Objective-C Garbage Collection
+#endif
+
+#if __has_feature(objc_arc)
+#error JSONKit does not support Objective-C Automatic Reference Counting (ARC)
+#endif
+
+// The following checks are really nothing more than sanity checks.
+// JSONKit technically has a few problems from a "strictly C99 conforming" standpoint, though they are of the pedantic nitpicking variety.
+// In practice, though, for the compilers and architectures we can reasonably expect this code to be compiled for, these pedantic nitpicks aren't really a problem.
+// Since we're limited as to what we can do with pre-processor #if checks, these checks are not nearly as through as they should be.
+
+#if (UINT_MAX != 0xffffffffU) || (INT_MIN != (-0x7fffffff-1)) || (ULLONG_MAX != 0xffffffffffffffffULL) || (LLONG_MIN != (-0x7fffffffffffffffLL-1LL))
+#error JSONKit requires the C 'int' and 'long long' types to be 32 and 64 bits respectively.
+#endif
+
+#if !defined(__LP64__) && ((UINT_MAX != ULONG_MAX) || (INT_MAX != LONG_MAX) || (INT_MIN != LONG_MIN) || (WORD_BIT != LONG_BIT))
+#error JSONKit requires the C 'int' and 'long' types to be the same on 32-bit architectures.
+#endif
+
+// Cocoa / Foundation uses NS*Integer as the type for a lot of arguments.  We make sure that NS*Integer is something we are expecting and is reasonably compatible with size_t / ssize_t
+
+#if (NSUIntegerMax != ULONG_MAX) || (NSIntegerMax != LONG_MAX) || (NSIntegerMin != LONG_MIN)
+#error JSONKit requires NSInteger and NSUInteger to be the same size as the C 'long' type.
+#endif
+
+#if (NSUIntegerMax != SIZE_MAX) || (NSIntegerMax != SSIZE_MAX)
+#error JSONKit requires NSInteger and NSUInteger to be the same size as the C 'size_t' type.
+#endif
+
+
+// For DJB hash.
+#define JK_HASH_INIT           (1402737925UL)
+
+// Use __builtin_clz() instead of trailingBytesForUTF8[] table lookup.
+#define JK_FAST_TRAILING_BYTES
+
+// JK_CACHE_SLOTS must be a power of 2.  Default size is 1024 slots.
+#define JK_CACHE_SLOTS_BITS    (10)
+#define JK_CACHE_SLOTS         (1UL << JK_CACHE_SLOTS_BITS)
+// JK_CACHE_PROBES is the number of probe attempts.
+#define JK_CACHE_PROBES        (4UL)
+// JK_INIT_CACHE_AGE must be (1 << AGE) - 1
+#define JK_INIT_CACHE_AGE      (0)
+
+// JK_TOKENBUFFER_SIZE is the default stack size for the temporary buffer used to hold "non-simple" strings (i.e., contains \ escapes)
+#define JK_TOKENBUFFER_SIZE    (1024UL * 2UL)
+
+// JK_STACK_OBJS is the default number of spaces reserved on the stack for temporarily storing pointers to Obj-C objects before they can be transferred to a NSArray / NSDictionary.
+#define JK_STACK_OBJS          (1024UL * 1UL)
+
+#define JK_JSONBUFFER_SIZE     (1024UL * 4UL)
+#define JK_UTF8BUFFER_SIZE     (1024UL * 16UL)
+
+#define JK_ENCODE_CACHE_SLOTS  (1024UL)
+
+
+#if       defined (__GNUC__) && (__GNUC__ >= 4)
+#define JK_ATTRIBUTES(attr, ...)        __attribute__((attr, ##__VA_ARGS__))
+#define JK_EXPECTED(cond, expect)       __builtin_expect((long)(cond), (expect))
+#define JK_EXPECT_T(cond)               JK_EXPECTED(cond, 1U)
+#define JK_EXPECT_F(cond)               JK_EXPECTED(cond, 0U)
+#define JK_PREFETCH(ptr)                __builtin_prefetch(ptr)
+#else  // defined (__GNUC__) && (__GNUC__ >= 4) 
+#define JK_ATTRIBUTES(attr, ...)
+#define JK_EXPECTED(cond, expect)       (cond)
+#define JK_EXPECT_T(cond)               (cond)
+#define JK_EXPECT_F(cond)               (cond)
+#define JK_PREFETCH(ptr)
+#endif // defined (__GNUC__) && (__GNUC__ >= 4) 
+
+#define JK_STATIC_INLINE                         static __inline__ JK_ATTRIBUTES(always_inline)
+#define JK_ALIGNED(arg)                                            JK_ATTRIBUTES(aligned(arg))
+#define JK_UNUSED_ARG                                              JK_ATTRIBUTES(unused)
+#define JK_WARN_UNUSED                                             JK_ATTRIBUTES(warn_unused_result)
+#define JK_WARN_UNUSED_CONST                                       JK_ATTRIBUTES(warn_unused_result, const)
+#define JK_WARN_UNUSED_PURE                                        JK_ATTRIBUTES(warn_unused_result, pure)
+#define JK_WARN_UNUSED_SENTINEL                                    JK_ATTRIBUTES(warn_unused_result, sentinel)
+#define JK_NONNULL_ARGS(arg, ...)                                  JK_ATTRIBUTES(nonnull(arg, ##__VA_ARGS__))
+#define JK_WARN_UNUSED_NONNULL_ARGS(arg, ...)                      JK_ATTRIBUTES(warn_unused_result, nonnull(arg, ##__VA_ARGS__))
+#define JK_WARN_UNUSED_CONST_NONNULL_ARGS(arg, ...)                JK_ATTRIBUTES(warn_unused_result, const, nonnull(arg, ##__VA_ARGS__))
+#define JK_WARN_UNUSED_PURE_NONNULL_ARGS(arg, ...)                 JK_ATTRIBUTES(warn_unused_result, pure, nonnull(arg, ##__VA_ARGS__))
+
+#if       defined (__GNUC__) && (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+#define JK_ALLOC_SIZE_NON_NULL_ARGS_WARN_UNUSED(as, nn, ...) JK_ATTRIBUTES(warn_unused_result, nonnull(nn, ##__VA_ARGS__), alloc_size(as))
+#else  // defined (__GNUC__) && (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+#define JK_ALLOC_SIZE_NON_NULL_ARGS_WARN_UNUSED(as, nn, ...) JK_ATTRIBUTES(warn_unused_result, nonnull(nn, ##__VA_ARGS__))
+#endif // defined (__GNUC__) && (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+
+
+@class JKArray, JKDictionaryEnumerator, JKDictionary;
+
+enum {
+  JSONNumberStateStart                 = 0,
+  JSONNumberStateFinished              = 1,
+  JSONNumberStateError                 = 2,
+  JSONNumberStateWholeNumberStart      = 3,
+  JSONNumberStateWholeNumberMinus      = 4,
+  JSONNumberStateWholeNumberZero       = 5,
+  JSONNumberStateWholeNumber           = 6,
+  JSONNumberStatePeriod                = 7,
+  JSONNumberStateFractionalNumberStart = 8,
+  JSONNumberStateFractionalNumber      = 9,
+  JSONNumberStateExponentStart         = 10,
+  JSONNumberStateExponentPlusMinus     = 11,
+  JSONNumberStateExponent              = 12,
+};
+
+enum {
+  JSONStringStateStart                           = 0,
+  JSONStringStateParsing                         = 1,
+  JSONStringStateFinished                        = 2,
+  JSONStringStateError                           = 3,
+  JSONStringStateEscape                          = 4,
+  JSONStringStateEscapedUnicode1                 = 5,
+  JSONStringStateEscapedUnicode2                 = 6,
+  JSONStringStateEscapedUnicode3                 = 7,
+  JSONStringStateEscapedUnicode4                 = 8,
+  JSONStringStateEscapedUnicodeSurrogate1        = 9,
+  JSONStringStateEscapedUnicodeSurrogate2        = 10,
+  JSONStringStateEscapedUnicodeSurrogate3        = 11,
+  JSONStringStateEscapedUnicodeSurrogate4        = 12,
+  JSONStringStateEscapedNeedEscapeForSurrogate   = 13,
+  JSONStringStateEscapedNeedEscapedUForSurrogate = 14,
+};
+
+enum {
+  JKParseAcceptValue      = (1 << 0),
+  JKParseAcceptComma      = (1 << 1),
+  JKParseAcceptEnd        = (1 << 2),
+  JKParseAcceptValueOrEnd = (JKParseAcceptValue | JKParseAcceptEnd),
+  JKParseAcceptCommaOrEnd = (JKParseAcceptComma | JKParseAcceptEnd),
+};
+
+enum {
+  JKClassUnknown    = 0,
+  JKClassString     = 1,
+  JKClassNumber     = 2,
+  JKClassArray      = 3,
+  JKClassDictionary = 4,
+  JKClassNull       = 5,
+};
+
+enum {
+  JKManagedBufferOnStack        = 1,
+  JKManagedBufferOnHeap         = 2,
+  JKManagedBufferLocationMask   = (0x3),
+  JKManagedBufferLocationShift  = (0),
+  
+  JKManagedBufferMustFree       = (1 << 2),
+};
+typedef JKFlags JKManagedBufferFlags;
+
+enum {
+  JKObjectStackOnStack        = 1,
+  JKObjectStackOnHeap         = 2,
+  JKObjectStackLocationMask   = (0x3),
+  JKObjectStackLocationShift  = (0),
+  
+  JKObjectStackMustFree       = (1 << 2),
+};
+typedef JKFlags JKObjectStackFlags;
+
+enum {
+  JKTokenTypeInvalid     = 0,
+  JKTokenTypeNumber      = 1,
+  JKTokenTypeString      = 2,
+  JKTokenTypeObjectBegin = 3,
+  JKTokenTypeObjectEnd   = 4,
+  JKTokenTypeArrayBegin  = 5,
+  JKTokenTypeArrayEnd    = 6,
+  JKTokenTypeSeparator   = 7,
+  JKTokenTypeComma       = 8,
+  JKTokenTypeTrue        = 9,
+  JKTokenTypeFalse       = 10,
+  JKTokenTypeNull        = 11,
+  JKTokenTypeWhiteSpace  = 12,
+};
+typedef NSUInteger JKTokenType;
+
+// These are prime numbers to assist with hash slot probing.
+enum {
+  JKValueTypeNone             = 0,
+  JKValueTypeString           = 5,
+  JKValueTypeLongLong         = 7,
+  JKValueTypeUnsignedLongLong = 11,
+  JKValueTypeDouble           = 13,
+};
+typedef NSUInteger JKValueType;
+
+enum {
+  JKEncodeOptionAsData              = 1,
+  JKEncodeOptionAsString            = 2,
+  JKEncodeOptionAsTypeMask          = 0x7,
+  JKEncodeOptionCollectionObj       = (1 << 3),
+  JKEncodeOptionStringObj           = (1 << 4),
+  JKEncodeOptionStringObjTrimQuotes = (1 << 5),
+  
+};
+typedef NSUInteger JKEncodeOptionType;
+
+typedef NSUInteger JKHash;
+
+typedef struct JKTokenCacheItem  JKTokenCacheItem;
+typedef struct JKTokenCache      JKTokenCache;
+typedef struct JKTokenValue      JKTokenValue;
+typedef struct JKParseToken      JKParseToken;
+typedef struct JKPtrRange        JKPtrRange;
+typedef struct JKObjectStack     JKObjectStack;
+typedef struct JKBuffer          JKBuffer;
+typedef struct JKConstBuffer     JKConstBuffer;
+typedef struct JKConstPtrRange   JKConstPtrRange;
+typedef struct JKRange           JKRange;
+typedef struct JKManagedBuffer   JKManagedBuffer;
+typedef struct JKFastClassLookup JKFastClassLookup;
+typedef struct JKEncodeCache     JKEncodeCache;
+typedef struct JKEncodeState     JKEncodeState;
+typedef struct JKObjCImpCache    JKObjCImpCache;
+typedef struct JKHashTableEntry  JKHashTableEntry;
+
+typedef id (*NSNumberAllocImp)(id receiver, SEL selector);
+typedef id (*NSNumberInitWithUnsignedLongLongImp)(id receiver, SEL selector, unsigned long long value);
+typedef id (*JKClassFormatterIMP)(id receiver, SEL selector, id object);
+#ifdef __BLOCKS__
+typedef id (^JKClassFormatterBlock)(id formatObject);
+#endif
+
+
+struct JKPtrRange {
+  unsigned char *ptr;
+  size_t         length;
+};
+
+struct JKConstPtrRange {
+  const unsigned char *ptr;
+  size_t               length;
+};
+
+struct JKRange {
+  size_t location, length;
+};
+
+struct JKManagedBuffer {
+  JKPtrRange           bytes;
+  JKManagedBufferFlags flags;
+  size_t               roundSizeUpToMultipleOf;
+};
+
+struct JKObjectStack {
+  void               **objects, **keys;
+  CFHashCode          *cfHashes;
+  size_t               count, index, roundSizeUpToMultipleOf;
+  JKObjectStackFlags   flags;
+};
+
+struct JKBuffer {
+  JKPtrRange bytes;
+};
+
+struct JKConstBuffer {
+  JKConstPtrRange bytes;
+};
+
+struct JKTokenValue {
+  JKConstPtrRange   ptrRange;
+  JKValueType       type;
+  JKHash            hash;
+  union {
+    long long          longLongValue;
+    unsigned long long unsignedLongLongValue;
+    double             doubleValue;
+  } number;
+  JKTokenCacheItem *cacheItem;
+};
+
+struct JKParseToken {
+  JKConstPtrRange tokenPtrRange;
+  JKTokenType     type;
+  JKTokenValue    value;
+  JKManagedBuffer tokenBuffer;
+};
+
+struct JKTokenCacheItem {
+  void          *object;
+  JKHash         hash;
+  CFHashCode     cfHash;
+  size_t         size;
+  unsigned char *bytes;
+  JKValueType    type;
+};
+
+struct JKTokenCache {
+  JKTokenCacheItem *items;
+  size_t            count;
+  unsigned int      prng_lfsr;
+  unsigned char     age[JK_CACHE_SLOTS];
+};
+
+struct JKObjCImpCache {
+  Class                               NSNumberClass;
+  NSNumberAllocImp                    NSNumberAlloc;
+  NSNumberInitWithUnsignedLongLongImp NSNumberInitWithUnsignedLongLong;
+};
+
+struct JKParseState {
+  JKParseOptionFlags  parseOptionFlags;
+  JKConstBuffer       stringBuffer;
+  size_t              atIndex, lineNumber, lineStartIndex;
+  size_t              prev_atIndex, prev_lineNumber, prev_lineStartIndex;
+  JKParseToken        token;
+  JKObjectStack       objectStack;
+  JKTokenCache        cache;
+  JKObjCImpCache      objCImpCache;
+  NSError            *error;
+  int                 errorIsPrev;
+  BOOL                mutableCollections;
+};
+
+struct JKFastClassLookup {
+  void *stringClass;
+  void *numberClass;
+  void *arrayClass;
+  void *dictionaryClass;
+  void *nullClass;
+};
+
+struct JKEncodeCache {
+  id object;
+  size_t offset;
+  size_t length;
+};
+
+struct JKEncodeState {
+  JKManagedBuffer         utf8ConversionBuffer;
+  JKManagedBuffer         stringBuffer;
+  size_t                  atIndex;
+  JKFastClassLookup       fastClassLookup;
+  JKEncodeCache           cache[JK_ENCODE_CACHE_SLOTS];
+  JKSerializeOptionFlags  serializeOptionFlags;
+  JKEncodeOptionType      encodeOption;
+  size_t                  depth;
+  NSError                *error;
+  id                      classFormatterDelegate;
+  SEL                     classFormatterSelector;
+  JKClassFormatterIMP     classFormatterIMP;
+#ifdef __BLOCKS__
+  JKClassFormatterBlock   classFormatterBlock;
+#endif
+};
+
+// This is a JSONKit private class.
+@interface JKSerializer : NSObject {
+  JKEncodeState *encodeState;
+}
+
+#ifdef __BLOCKS__
+#define JKSERIALIZER_BLOCKS_PROTO id(^)(id object)
+#else
+#define JKSERIALIZER_BLOCKS_PROTO id
+#endif
+
++ (id)serializeObject:(id)object options:(JKSerializeOptionFlags)optionFlags encodeOption:(JKEncodeOptionType)encodeOption block:(JKSERIALIZER_BLOCKS_PROTO)block delegate:(id)delegate selector:(SEL)selector error:(NSError **)error;
+- (id)serializeObject:(id)object options:(JKSerializeOptionFlags)optionFlags encodeOption:(JKEncodeOptionType)encodeOption block:(JKSERIALIZER_BLOCKS_PROTO)block delegate:(id)delegate selector:(SEL)selector error:(NSError **)error;
+- (void)releaseState;
+
+@end
+
+struct JKHashTableEntry {
+  NSUInteger keyHash;
+  id key, object;
+};
+
+
+typedef uint32_t UTF32; /* at least 32 bits */
+typedef uint16_t UTF16; /* at least 16 bits */
+typedef uint8_t  UTF8;  /* typically 8 bits */
+
+typedef enum {
+  conversionOK,           /* conversion successful */
+  sourceExhausted,        /* partial character in source, but hit end */
+  targetExhausted,        /* insuff. room in target for conversion */
+  sourceIllegal           /* source sequence is illegal/malformed */
+} ConversionResult;
+
+#define UNI_REPLACEMENT_CHAR (UTF32)0x0000FFFD
+#define UNI_MAX_BMP          (UTF32)0x0000FFFF
+#define UNI_MAX_UTF16        (UTF32)0x0010FFFF
+#define UNI_MAX_UTF32        (UTF32)0x7FFFFFFF
+#define UNI_MAX_LEGAL_UTF32  (UTF32)0x0010FFFF
+#define UNI_SUR_HIGH_START   (UTF32)0xD800
+#define UNI_SUR_HIGH_END     (UTF32)0xDBFF
+#define UNI_SUR_LOW_START    (UTF32)0xDC00
+#define UNI_SUR_LOW_END      (UTF32)0xDFFF
+
+
+#if !defined(JK_FAST_TRAILING_BYTES)
+static const char trailingBytesForUTF8[256] = {
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
+};
+#endif
+
+static const UTF32 offsetsFromUTF8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080UL, 0x03C82080UL, 0xFA082080UL, 0x82082080UL };
+static const UTF8  firstByteMark[7]   = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+
+#define JK_AT_STRING_PTR(x)  (&((x)->stringBuffer.bytes.ptr[(x)->atIndex]))
+#define JK_END_STRING_PTR(x) (&((x)->stringBuffer.bytes.ptr[(x)->stringBuffer.bytes.length]))
+
+
+static JKArray          *_JKArrayCreate(id *objects, NSUInteger count, BOOL mutableCollection);
+static void              _JKArrayInsertObjectAtIndex(JKArray *array, id newObject, NSUInteger objectIndex);
+static void              _JKArrayReplaceObjectAtIndexWithObject(JKArray *array, NSUInteger objectIndex, id newObject);
+static void              _JKArrayRemoveObjectAtIndex(JKArray *array, NSUInteger objectIndex);
+
+
+static NSUInteger        _JKDictionaryCapacityForCount(NSUInteger count);
+static JKDictionary     *_JKDictionaryCreate(id *keys, NSUInteger *keyHashes, id *objects, NSUInteger count, BOOL mutableCollection);
+static JKHashTableEntry *_JKDictionaryHashEntry(JKDictionary *dictionary);
+static NSUInteger        _JKDictionaryCapacity(JKDictionary *dictionary);
+static void              _JKDictionaryResizeIfNeccessary(JKDictionary *dictionary);
+static void              _JKDictionaryRemoveObjectWithEntry(JKDictionary *dictionary, JKHashTableEntry *entry);
+static void              _JKDictionaryAddObject(JKDictionary *dictionary, NSUInteger keyHash, id key, id object);
+static JKHashTableEntry *_JKDictionaryHashTableEntryForKey(JKDictionary *dictionary, id aKey);
+
+
+static void _JSONDecoderCleanup(JSONDecoder *decoder);
+
+static id _NSStringObjectFromJSONString(NSString *jsonString, JKParseOptionFlags parseOptionFlags, NSError **error, BOOL mutableCollection);
+
+
+static void jk_managedBuffer_release(JKManagedBuffer *managedBuffer);
+static void jk_managedBuffer_setToStackBuffer(JKManagedBuffer *managedBuffer, unsigned char *ptr, size_t length);
+static unsigned char *jk_managedBuffer_resize(JKManagedBuffer *managedBuffer, size_t newSize);
+static void jk_objectStack_release(JKObjectStack *objectStack);
+static void jk_objectStack_setToStackBuffer(JKObjectStack *objectStack, void **objects, void **keys, CFHashCode *cfHashes, size_t count);
+static int  jk_objectStack_resize(JKObjectStack *objectStack, size_t newCount);
+
+static void   jk_error(JKParseState *parseState, NSString *format, ...);
+static int    jk_parse_string(JKParseState *parseState);
+static int    jk_parse_number(JKParseState *parseState);
+static size_t jk_parse_is_newline(JKParseState *parseState, const unsigned char *atCharacterPtr);
+JK_STATIC_INLINE int jk_parse_skip_newline(JKParseState *parseState);
+JK_STATIC_INLINE void jk_parse_skip_whitespace(JKParseState *parseState);
+static int    jk_parse_next_token(JKParseState *parseState);
+static void   jk_error_parse_accept_or3(JKParseState *parseState, int state, NSString *or1String, NSString *or2String, NSString *or3String);
+static void  *jk_create_dictionary(JKParseState *parseState, size_t startingObjectIndex);
+static void  *jk_parse_dictionary(JKParseState *parseState);
+static void  *jk_parse_array(JKParseState *parseState);
+static void  *jk_object_for_token(JKParseState *parseState);
+static void  *jk_cachedObjects(JKParseState *parseState);
+JK_STATIC_INLINE void jk_cache_age(JKParseState *parseState);
+JK_STATIC_INLINE void jk_set_parsed_token(JKParseState *parseState, const unsigned char *ptr, size_t length, JKTokenType type, size_t advanceBy);
+
+
+static void jk_encode_error(JKEncodeState *encodeState, NSString *format, ...);
+static int jk_encode_printf(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object, const char *format, ...);
+static int jk_encode_write(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object, const char *format);
+static int jk_encode_writePrettyPrintWhiteSpace(JKEncodeState *encodeState);
+static int jk_encode_write1slow(JKEncodeState *encodeState, ssize_t depthChange, const char *format);
+static int jk_encode_write1fast(JKEncodeState *encodeState, ssize_t depthChange JK_UNUSED_ARG, const char *format);
+static int jk_encode_writen(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object, const char *format, size_t length);
+JK_STATIC_INLINE JKHash jk_encode_object_hash(void *objectPtr);
+JK_STATIC_INLINE void jk_encode_updateCache(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object);
+static int jk_encode_add_atom_to_buffer(JKEncodeState *encodeState, void *objectPtr);
+
+#define jk_encode_write1(es, dc, f)  (JK_EXPECT_F(_jk_encode_prettyPrint) ? jk_encode_write1slow(es, dc, f) : jk_encode_write1fast(es, dc, f))
+
+
+JK_STATIC_INLINE size_t jk_min(size_t a, size_t b);
+JK_STATIC_INLINE size_t jk_max(size_t a, size_t b);
+JK_STATIC_INLINE JKHash calculateHash(JKHash currentHash, unsigned char c);
+
+// JSONKit v1.4 used both a JKArray : NSArray and JKMutableArray : NSMutableArray, and the same for the dictionary collection type.
+// However, Louis Gerbarg (via cocoa-dev) pointed out that Cocoa / Core Foundation actually implements only a single class that inherits from the 
+// mutable version, and keeps an ivar bit for whether or not that instance is mutable.  This means that the immutable versions of the collection
+// classes receive the mutating methods, but this is handled by having those methods throw an exception when the ivar bit is set to immutable.
+// We adopt the same strategy here.  It's both cleaner and gets rid of the method swizzling hackery used in JSONKit v1.4.
+
+
+// This is a workaround for issue #23 https://github.com/johnezang/JSONKit/pull/23
+// Basically, there seem to be a problem with using +load in static libraries on iOS.  However, __attribute__ ((constructor)) does work correctly.
+// Since we do not require anything "special" that +load provides, and we can accomplish the same thing using __attribute__ ((constructor)), the +load logic was moved here.
+
+static Class                               _JKArrayClass                           = NULL;
+static size_t                              _JKArrayInstanceSize                    = 0UL;
+static Class                               _JKDictionaryClass                      = NULL;
+static size_t                              _JKDictionaryInstanceSize               = 0UL;
+
+// For JSONDecoder...
+static Class                               _jk_NSNumberClass                       = NULL;
+static NSNumberAllocImp                    _jk_NSNumberAllocImp                    = NULL;
+static NSNumberInitWithUnsignedLongLongImp _jk_NSNumberInitWithUnsignedLongLongImp = NULL;
+
+extern void jk_collectionClassLoadTimeInitialization(void) __attribute__ ((constructor));
+
+void jk_collectionClassLoadTimeInitialization(void) {
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init]; // Though technically not required, the run time environment at load time initialization may be less than ideal.
+  
+  _JKArrayClass             = objc_getClass("JKArray");
+  _JKArrayInstanceSize      = jk_max(16UL, class_getInstanceSize(_JKArrayClass));
+  
+  _JKDictionaryClass        = objc_getClass("JKDictionary");
+  _JKDictionaryInstanceSize = jk_max(16UL, class_getInstanceSize(_JKDictionaryClass));
+  
+  // For JSONDecoder...
+  _jk_NSNumberClass = [NSNumber class];
+  _jk_NSNumberAllocImp = (NSNumberAllocImp)[NSNumber methodForSelector:@selector(alloc)];
+  
+  // Hacktacular.  Need to do it this way due to the nature of class clusters.
+  id temp_NSNumber = [NSNumber alloc];
+  _jk_NSNumberInitWithUnsignedLongLongImp = (NSNumberInitWithUnsignedLongLongImp)[temp_NSNumber methodForSelector:@selector(initWithUnsignedLongLong:)];
+  [[temp_NSNumber init] release];
+  temp_NSNumber = NULL;
+  
+  [pool release]; pool = NULL;
+}
+
+
+#pragma mark -
+@interface JKArray : NSMutableArray <NSCopying, NSMutableCopying, NSFastEnumeration> {
+  id         *objects;
+  NSUInteger  count, capacity, mutations;
+}
+@end
+
+@implementation JKArray
+
++ (id)allocWithZone:(NSZone *)zone
+{
+#pragma unused(zone)
+  [NSException raise:NSInvalidArgumentException format:@"*** - [%@ %@]: The %@ class is private to JSONKit and should not be used in this fashion.", NSStringFromClass([self class]), NSStringFromSelector(_cmd), NSStringFromClass([self class])];
+  return(NULL);
+}
+
+static JKArray *_JKArrayCreate(id *objects, NSUInteger count, BOOL mutableCollection) {
+  NSCParameterAssert((objects != NULL) && (_JKArrayClass != NULL) && (_JKArrayInstanceSize > 0UL));
+  JKArray *array = NULL;
+  if(JK_EXPECT_T((array = (JKArray *)calloc(1UL, _JKArrayInstanceSize)) != NULL)) { // Directly allocate the JKArray instance via calloc.
+    array->isa      = _JKArrayClass;
+    if((array = [array init]) == NULL) { return(NULL); }
+    array->capacity = count;
+    array->count    = count;
+    if(JK_EXPECT_F((array->objects = (id *)malloc(sizeof(id) * array->capacity)) == NULL)) { [array autorelease]; return(NULL); }
+    memcpy(array->objects, objects, array->capacity * sizeof(id));
+    array->mutations = (mutableCollection == NO) ? 0UL : 1UL;
+  }
+  return(array);
+}
+
+// Note: The caller is responsible for -retaining the object that is to be added.
+static void _JKArrayInsertObjectAtIndex(JKArray *array, id newObject, NSUInteger objectIndex) {
+  NSCParameterAssert((array != NULL) && (array->objects != NULL) && (array->count <= array->capacity) && (objectIndex <= array->count) && (newObject != NULL));
+  if(!((array != NULL) && (array->objects != NULL) && (objectIndex <= array->count) && (newObject != NULL))) { [newObject autorelease]; return; }
+  array->count++;
+  if(array->count >= array->capacity) {
+    array->capacity += 16UL;
+    id *newObjects = NULL;
+    if((newObjects = (id *)realloc(array->objects, sizeof(id) * array->capacity)) == NULL) { [NSException raise:NSMallocException format:@"Unable to resize objects array."]; }
+    array->objects = newObjects;
+    memset(&array->objects[array->count], 0, sizeof(id) * (array->capacity - array->count));
+  }
+  if((objectIndex + 1UL) < array->count) { memmove(&array->objects[objectIndex + 1UL], &array->objects[objectIndex], sizeof(id) * ((array->count - 1UL) - objectIndex)); array->objects[objectIndex] = NULL; }
+  array->objects[objectIndex] = newObject;
+}
+
+// Note: The caller is responsible for -retaining the object that is to be added.
+static void _JKArrayReplaceObjectAtIndexWithObject(JKArray *array, NSUInteger objectIndex, id newObject) {
+  NSCParameterAssert((array != NULL) && (array->objects != NULL) && (array->count <= array->capacity) && (objectIndex < array->count) && (array->objects[objectIndex] != NULL) && (newObject != NULL));
+  if(!((array != NULL) && (array->objects != NULL) && (objectIndex < array->count) && (array->objects[objectIndex] != NULL) && (newObject != NULL))) { [newObject autorelease]; return; }
+  CFRelease(array->objects[objectIndex]);
+  array->objects[objectIndex] = NULL;
+  array->objects[objectIndex] = newObject;
+}
+
+static void _JKArrayRemoveObjectAtIndex(JKArray *array, NSUInteger objectIndex) {
+  NSCParameterAssert((array != NULL) && (array->objects != NULL) && (array->count <= array->capacity) && (objectIndex < array->count) && (array->objects[objectIndex] != NULL));
+  if(!((array != NULL) && (array->objects != NULL) && (objectIndex < array->count) && (array->objects[objectIndex] != NULL))) { return; }
+  CFRelease(array->objects[objectIndex]);
+  array->objects[objectIndex] = NULL;
+  if((objectIndex + 1UL) < array->count) { memmove(&array->objects[objectIndex], &array->objects[objectIndex + 1UL], sizeof(id) * ((array->count - 1UL) - objectIndex)); array->objects[array->count] = NULL; }
+  array->count--;
+}
+
+- (void)dealloc
+{
+  if(JK_EXPECT_T(objects != NULL)) {
+    NSUInteger atObject = 0UL;
+    for(atObject = 0UL; atObject < count; atObject++) { if(JK_EXPECT_T(objects[atObject] != NULL)) { CFRelease(objects[atObject]); objects[atObject] = NULL; } }
+    free(objects); objects = NULL;
+  }
+  
+  [super dealloc];
+}
+
+- (NSUInteger)count
+{
+  NSParameterAssert((objects != NULL) && (count <= capacity));
+  return(count);
+}
+
+- (void)getObjects:(id *)objectsPtr range:(NSRange)range
+{
+  NSParameterAssert((objects != NULL) && (count <= capacity));
+  if((objectsPtr     == NULL)  && (NSMaxRange(range) > 0UL))   { [NSException raise:NSRangeException format:@"*** -[%@ %@]: pointer to objects array is NULL but range length is %lu", NSStringFromClass([self class]), NSStringFromSelector(_cmd), NSMaxRange(range)];        }
+  if((range.location >  count) || (NSMaxRange(range) > count)) { [NSException raise:NSRangeException format:@"*** -[%@ %@]: index (%lu) beyond bounds (%lu)",                          NSStringFromClass([self class]), NSStringFromSelector(_cmd), NSMaxRange(range), count]; }
+  memcpy(objectsPtr, objects + range.location, range.length * sizeof(id));
+}
+
+- (id)objectAtIndex:(NSUInteger)objectIndex
+{
+  if(objectIndex >= count) { [NSException raise:NSRangeException format:@"*** -[%@ %@]: index (%lu) beyond bounds (%lu)", NSStringFromClass([self class]), NSStringFromSelector(_cmd), objectIndex, count]; }
+  NSParameterAssert((objects != NULL) && (count <= capacity) && (objects[objectIndex] != NULL));
+  return(objects[objectIndex]);
+}
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id *)stackbuf count:(NSUInteger)len
+{
+  NSParameterAssert((state != NULL) && (stackbuf != NULL) && (len > 0UL) && (objects != NULL) && (count <= capacity));
+  if(JK_EXPECT_F(state->state == 0UL))   { state->mutationsPtr = (unsigned long *)&mutations; state->itemsPtr = stackbuf; }
+  if(JK_EXPECT_F(state->state >= count)) { return(0UL); }
+  
+  NSUInteger enumeratedCount  = 0UL;
+  while(JK_EXPECT_T(enumeratedCount < len) && JK_EXPECT_T(state->state < count)) { NSParameterAssert(objects[state->state] != NULL); stackbuf[enumeratedCount++] = objects[state->state++]; }
+  
+  return(enumeratedCount);
+}
+
+- (void)insertObject:(id)anObject atIndex:(NSUInteger)objectIndex
+{
+  if(mutations   == 0UL)   { [NSException raise:NSInternalInconsistencyException format:@"*** -[%@ %@]: mutating method sent to immutable object", NSStringFromClass([self class]), NSStringFromSelector(_cmd)]; }
+  if(anObject    == NULL)  { [NSException raise:NSInvalidArgumentException       format:@"*** -[%@ %@]: attempt to insert nil",                    NSStringFromClass([self class]), NSStringFromSelector(_cmd)]; }
+  if(objectIndex >  count) { [NSException raise:NSRangeException                 format:@"*** -[%@ %@]: index (%lu) beyond bounds (%lu)",          NSStringFromClass([self class]), NSStringFromSelector(_cmd), objectIndex, count + 1UL]; }
+#ifdef __clang_analyzer__
+  [anObject retain]; // Stupid clang analyzer...  Issue #19.
+#else
+  anObject = [anObject retain];
+#endif
+  _JKArrayInsertObjectAtIndex(self, anObject, objectIndex);
+  mutations = (mutations == NSUIntegerMax) ? 1UL : mutations + 1UL;
+}
+
+- (void)removeObjectAtIndex:(NSUInteger)objectIndex
+{
+  if(mutations   == 0UL)   { [NSException raise:NSInternalInconsistencyException format:@"*** -[%@ %@]: mutating method sent to immutable object", NSStringFromClass([self class]), NSStringFromSelector(_cmd)]; }
+  if(objectIndex >= count) { [NSException raise:NSRangeException                 format:@"*** -[%@ %@]: index (%lu) beyond bounds (%lu)",          NSStringFromClass([self class]), NSStringFromSelector(_cmd), objectIndex, count]; }
+  _JKArrayRemoveObjectAtIndex(self, objectIndex);
+  mutations = (mutations == NSUIntegerMax) ? 1UL : mutations + 1UL;
+}
+
+- (void)replaceObjectAtIndex:(NSUInteger)objectIndex withObject:(id)anObject
+{
+  if(mutations   == 0UL)   { [NSException raise:NSInternalInconsistencyException format:@"*** -[%@ %@]: mutating method sent to immutable object", NSStringFromClass([self class]), NSStringFromSelector(_cmd)]; }
+  if(anObject    == NULL)  { [NSException raise:NSInvalidArgumentException       format:@"*** -[%@ %@]: attempt to insert nil",                    NSStringFromClass([self class]), NSStringFromSelector(_cmd)]; }
+  if(objectIndex >= count) { [NSException raise:NSRangeException                 format:@"*** -[%@ %@]: index (%lu) beyond bounds (%lu)",          NSStringFromClass([self class]), NSStringFromSelector(_cmd), objectIndex, count]; }
+#ifdef __clang_analyzer__
+  [anObject retain]; // Stupid clang analyzer...  Issue #19.
+#else
+  anObject = [anObject retain];
+#endif
+  _JKArrayReplaceObjectAtIndexWithObject(self, objectIndex, anObject);
+  mutations = (mutations == NSUIntegerMax) ? 1UL : mutations + 1UL;
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+  NSParameterAssert((objects != NULL) && (count <= capacity));
+  return((mutations == 0UL) ? [self retain] : [[NSArray allocWithZone:zone] initWithObjects:objects count:count]);
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone
+{
+  NSParameterAssert((objects != NULL) && (count <= capacity));
+  return([[NSMutableArray allocWithZone:zone] initWithObjects:objects count:count]);
+}
+
+@end
+
+
+#pragma mark -
+@interface JKDictionaryEnumerator : NSEnumerator {
+  id         collection;
+  NSUInteger nextObject;
+}
+
+- (id)initWithJKDictionary:(JKDictionary *)initDictionary;
+- (NSArray *)allObjects;
+- (id)nextObject;
+
+@end
+
+@implementation JKDictionaryEnumerator
+
+- (id)initWithJKDictionary:(JKDictionary *)initDictionary
+{
+  NSParameterAssert(initDictionary != NULL);
+  if((self = [super init]) == NULL) { return(NULL); }
+  if((collection = (id)CFRetain(initDictionary)) == NULL) { [self autorelease]; return(NULL); }
+  return(self);
+}
+
+- (void)dealloc
+{
+  if(collection != NULL) { CFRelease(collection); collection = NULL; }
+  [super dealloc];
+}
+
+- (NSArray *)allObjects
+{
+  NSParameterAssert(collection != NULL);
+  NSUInteger count = [collection count], atObject = 0UL;
+  id         objects[count];
+
+  while((objects[atObject] = [self nextObject]) != NULL) { NSParameterAssert(atObject < count); atObject++; }
+
+  return([NSArray arrayWithObjects:objects count:atObject]);
+}
+
+- (id)nextObject
+{
+  NSParameterAssert((collection != NULL) && (_JKDictionaryHashEntry(collection) != NULL));
+  JKHashTableEntry *entry        = _JKDictionaryHashEntry(collection);
+  NSUInteger        capacity     = _JKDictionaryCapacity(collection);
+  id                returnObject = NULL;
+
+  if(entry != NULL) { while((nextObject < capacity) && ((returnObject = entry[nextObject++].key) == NULL)) { /* ... */ } }
+  
+  return(returnObject);
+}
+
+@end
+
+#pragma mark -
+@interface JKDictionary : NSMutableDictionary <NSCopying, NSMutableCopying, NSFastEnumeration> {
+  NSUInteger count, capacity, mutations;
+  JKHashTableEntry *entry;
+}
+@end
+
+@implementation JKDictionary
+
++ (id)allocWithZone:(NSZone *)zone
+{
+#pragma unused(zone)
+  [NSException raise:NSInvalidArgumentException format:@"*** - [%@ %@]: The %@ class is private to JSONKit and should not be used in this fashion.", NSStringFromClass([self class]), NSStringFromSelector(_cmd), NSStringFromClass([self class])];
+  return(NULL);
+}
+
+// These values are taken from Core Foundation CF-550 CFBasicHash.m.  As a bonus, they align very well with our JKHashTableEntry struct too.
+static const NSUInteger jk_dictionaryCapacities[] = {
+  0UL, 3UL, 7UL, 13UL, 23UL, 41UL, 71UL, 127UL, 191UL, 251UL, 383UL, 631UL, 1087UL, 1723UL,
+  2803UL, 4523UL, 7351UL, 11959UL, 19447UL, 31231UL, 50683UL, 81919UL, 132607UL,
+  214519UL, 346607UL, 561109UL, 907759UL, 1468927UL, 2376191UL, 3845119UL,
+  6221311UL, 10066421UL, 16287743UL, 26354171UL, 42641881UL, 68996069UL,
+  111638519UL, 180634607UL, 292272623UL, 472907251UL
+};
+
+static NSUInteger _JKDictionaryCapacityForCount(NSUInteger count) {
+  NSUInteger bottom = 0UL, top = sizeof(jk_dictionaryCapacities) / sizeof(NSUInteger), mid = 0UL, tableSize = lround(floor((count) * 1.33));
+  while(top > bottom) { mid = (top + bottom) / 2UL; if(jk_dictionaryCapacities[mid] < tableSize) { bottom = mid + 1UL; } else { top = mid; } }
+  return(jk_dictionaryCapacities[bottom]);
+}
+
+static void _JKDictionaryResizeIfNeccessary(JKDictionary *dictionary) {
+  NSCParameterAssert((dictionary != NULL) && (dictionary->entry != NULL) && (dictionary->count <= dictionary->capacity));
+
+  NSUInteger capacityForCount = 0UL;
+  if(dictionary->capacity < (capacityForCount = _JKDictionaryCapacityForCount(dictionary->count + 1UL))) { // resize
+    NSUInteger        oldCapacity = dictionary->capacity;
+#ifndef NS_BLOCK_ASSERTIONS
+    NSUInteger oldCount = dictionary->count;
+#endif
+    JKHashTableEntry *oldEntry    = dictionary->entry;
+    if(JK_EXPECT_F((dictionary->entry = (JKHashTableEntry *)calloc(1UL, sizeof(JKHashTableEntry) * capacityForCount)) == NULL)) { [NSException raise:NSMallocException format:@"Unable to allocate memory for hash table."]; }
+    dictionary->capacity = capacityForCount;
+    dictionary->count    = 0UL;
+    
+    NSUInteger idx = 0UL;
+    for(idx = 0UL; idx < oldCapacity; idx++) { if(oldEntry[idx].key != NULL) { _JKDictionaryAddObject(dictionary, oldEntry[idx].keyHash, oldEntry[idx].key, oldEntry[idx].object); oldEntry[idx].keyHash = 0UL; oldEntry[idx].key = NULL; oldEntry[idx].object = NULL; } }
+    NSCParameterAssert((oldCount == dictionary->count));
+    free(oldEntry); oldEntry = NULL;
+  }
+}
+
+static JKDictionary *_JKDictionaryCreate(id *keys, NSUInteger *keyHashes, id *objects, NSUInteger count, BOOL mutableCollection) {
+  NSCParameterAssert((keys != NULL) && (keyHashes != NULL) && (objects != NULL) && (_JKDictionaryClass != NULL) && (_JKDictionaryInstanceSize > 0UL));
+  JKDictionary *dictionary = NULL;
+  if(JK_EXPECT_T((dictionary = (JKDictionary *)calloc(1UL, _JKDictionaryInstanceSize)) != NULL)) { // Directly allocate the JKDictionary instance via calloc.
+    dictionary->isa      = _JKDictionaryClass;
+    if((dictionary = [dictionary init]) == NULL) { return(NULL); }
+    dictionary->capacity = _JKDictionaryCapacityForCount(count);
+    dictionary->count    = 0UL;
+    
+    if(JK_EXPECT_F((dictionary->entry = (JKHashTableEntry *)calloc(1UL, sizeof(JKHashTableEntry) * dictionary->capacity)) == NULL)) { [dictionary autorelease]; return(NULL); }
+
+    NSUInteger idx = 0UL;
+    for(idx = 0UL; idx < count; idx++) { _JKDictionaryAddObject(dictionary, keyHashes[idx], keys[idx], objects[idx]); }
+
+    dictionary->mutations = (mutableCollection == NO) ? 0UL : 1UL;
+  }
+  return(dictionary);
+}
+
+- (void)dealloc
+{
+  if(JK_EXPECT_T(entry != NULL)) {
+    NSUInteger atEntry = 0UL;
+    for(atEntry = 0UL; atEntry < capacity; atEntry++) {
+      if(JK_EXPECT_T(entry[atEntry].key    != NULL)) { CFRelease(entry[atEntry].key);    entry[atEntry].key    = NULL; }
+      if(JK_EXPECT_T(entry[atEntry].object != NULL)) { CFRelease(entry[atEntry].object); entry[atEntry].object = NULL; }
+    }
+  
+    free(entry); entry = NULL;
+  }
+
+  [super dealloc];
+}
+
+static JKHashTableEntry *_JKDictionaryHashEntry(JKDictionary *dictionary) {
+  NSCParameterAssert(dictionary != NULL);
+  return(dictionary->entry);
+}
+
+static NSUInteger _JKDictionaryCapacity(JKDictionary *dictionary) {
+  NSCParameterAssert(dictionary != NULL);
+  return(dictionary->capacity);
+}
+
+static void _JKDictionaryRemoveObjectWithEntry(JKDictionary *dictionary, JKHashTableEntry *entry) {
+  NSCParameterAssert((dictionary != NULL) && (entry != NULL) && (entry->key != NULL) && (entry->object != NULL) && (dictionary->count > 0UL) && (dictionary->count <= dictionary->capacity));
+  CFRelease(entry->key);    entry->key    = NULL;
+  CFRelease(entry->object); entry->object = NULL;
+  entry->keyHash = 0UL;
+  dictionary->count--;
+  // In order for certain invariants that are used to speed up the search for a particular key, we need to "re-add" all the entries in the hash table following this entry until we hit a NULL entry.
+  NSUInteger removeIdx = entry - dictionary->entry, idx = 0UL;
+  NSCParameterAssert((removeIdx < dictionary->capacity));
+  for(idx = 0UL; idx < dictionary->capacity; idx++) {
+    NSUInteger entryIdx = (removeIdx + idx + 1UL) % dictionary->capacity;
+    JKHashTableEntry *atEntry = &dictionary->entry[entryIdx];
+    if(atEntry->key == NULL) { break; }
+    NSUInteger keyHash = atEntry->keyHash;
+    id key = atEntry->key, object = atEntry->object;
+    NSCParameterAssert(object != NULL);
+    atEntry->keyHash = 0UL;
+    atEntry->key     = NULL;
+    atEntry->object  = NULL;
+    NSUInteger addKeyEntry = keyHash % dictionary->capacity, addIdx = 0UL;
+    for(addIdx = 0UL; addIdx < dictionary->capacity; addIdx++) {
+      JKHashTableEntry *atAddEntry = &dictionary->entry[((addKeyEntry + addIdx) % dictionary->capacity)];
+      if(JK_EXPECT_T(atAddEntry->key == NULL)) { NSCParameterAssert((atAddEntry->keyHash == 0UL) && (atAddEntry->object == NULL)); atAddEntry->key = key; atAddEntry->object = object; atAddEntry->keyHash = keyHash; break; }
+    }
+  }
+}
+
+static void _JKDictionaryAddObject(JKDictionary *dictionary, NSUInteger keyHash, id key, id object) {
+  NSCParameterAssert((dictionary != NULL) && (key != NULL) && (object != NULL) && (dictionary->count < dictionary->capacity) && (dictionary->entry != NULL));
+  NSUInteger keyEntry = keyHash % dictionary->capacity, idx = 0UL;
+  for(idx = 0UL; idx < dictionary->capacity; idx++) {
+    NSUInteger entryIdx = (keyEntry + idx) % dictionary->capacity;
+    JKHashTableEntry *atEntry = &dictionary->entry[entryIdx];
+    if(JK_EXPECT_F(atEntry->keyHash == keyHash) && JK_EXPECT_T(atEntry->key != NULL) && (JK_EXPECT_F(key == atEntry->key) || JK_EXPECT_F(CFEqual(atEntry->key, key)))) { _JKDictionaryRemoveObjectWithEntry(dictionary, atEntry); }
+    if(JK_EXPECT_T(atEntry->key == NULL)) { NSCParameterAssert((atEntry->keyHash == 0UL) && (atEntry->object == NULL)); atEntry->key = key; atEntry->object = object; atEntry->keyHash = keyHash; dictionary->count++; return; }
+  }
+
+  // We should never get here.  If we do, we -release the key / object because it's our responsibility.
+  CFRelease(key);
+  CFRelease(object);
+}
+
+- (NSUInteger)count
+{
+  return(count);
+}
+
+static JKHashTableEntry *_JKDictionaryHashTableEntryForKey(JKDictionary *dictionary, id aKey) {
+  NSCParameterAssert((dictionary != NULL) && (dictionary->entry != NULL) && (dictionary->count <= dictionary->capacity));
+  if((aKey == NULL) || (dictionary->capacity == 0UL)) { return(NULL); }
+  NSUInteger        keyHash = CFHash(aKey), keyEntry = (keyHash % dictionary->capacity), idx = 0UL;
+  JKHashTableEntry *atEntry = NULL;
+  for(idx = 0UL; idx < dictionary->capacity; idx++) {
+    atEntry = &dictionary->entry[(keyEntry + idx) % dictionary->capacity];
+    if(JK_EXPECT_T(atEntry->keyHash == keyHash) && JK_EXPECT_T(atEntry->key != NULL) && ((atEntry->key == aKey) || CFEqual(atEntry->key, aKey))) { NSCParameterAssert(atEntry->object != NULL); return(atEntry); break; }
+    if(JK_EXPECT_F(atEntry->key == NULL)) { NSCParameterAssert(atEntry->object == NULL); return(NULL); break; } // If the key was in the table, we would have found it by now.
+  }
+  return(NULL);
+}
+
+- (id)objectForKey:(id)aKey
+{
+  NSParameterAssert((entry != NULL) && (count <= capacity));
+  JKHashTableEntry *entryForKey = _JKDictionaryHashTableEntryForKey(self, aKey);
+  return((entryForKey != NULL) ? entryForKey->object : NULL);
+}
+
+- (void)getObjects:(id *)objects andKeys:(id *)keys
+{
+  NSParameterAssert((entry != NULL) && (count <= capacity));
+  NSUInteger atEntry = 0UL; NSUInteger arrayIdx = 0UL;
+  for(atEntry = 0UL; atEntry < capacity; atEntry++) {
+    if(JK_EXPECT_T(entry[atEntry].key != NULL)) {
+      NSCParameterAssert((entry[atEntry].object != NULL) && (arrayIdx < count));
+      if(JK_EXPECT_T(keys    != NULL)) { keys[arrayIdx]    = entry[atEntry].key;    }
+      if(JK_EXPECT_T(objects != NULL)) { objects[arrayIdx] = entry[atEntry].object; }
+      arrayIdx++;
+    }
+  }
+}
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id *)stackbuf count:(NSUInteger)len
+{
+  NSParameterAssert((state != NULL) && (stackbuf != NULL) && (len > 0UL) && (entry != NULL) && (count <= capacity));
+  if(JK_EXPECT_F(state->state == 0UL))      { state->mutationsPtr = (unsigned long *)&mutations; state->itemsPtr = stackbuf; }
+  if(JK_EXPECT_F(state->state >= capacity)) { return(0UL); }
+  
+  NSUInteger enumeratedCount  = 0UL;
+  while(JK_EXPECT_T(enumeratedCount < len) && JK_EXPECT_T(state->state < capacity)) { if(JK_EXPECT_T(entry[state->state].key != NULL)) { stackbuf[enumeratedCount++] = entry[state->state].key; } state->state++; }
+    
+  return(enumeratedCount);
+}
+
+- (NSEnumerator *)keyEnumerator
+{
+  return([[[JKDictionaryEnumerator alloc] initWithJKDictionary:self] autorelease]);
+}
+
+- (void)setObject:(id)anObject forKey:(id)aKey
+{
+  if(mutations == 0UL)  { [NSException raise:NSInternalInconsistencyException format:@"*** -[%@ %@]: mutating method sent to immutable object", NSStringFromClass([self class]), NSStringFromSelector(_cmd)];       }
+  if(aKey      == NULL) { [NSException raise:NSInvalidArgumentException       format:@"*** -[%@ %@]: attempt to insert nil key",                NSStringFromClass([self class]), NSStringFromSelector(_cmd)];       }
+  if(anObject  == NULL) { [NSException raise:NSInvalidArgumentException       format:@"*** -[%@ %@]: attempt to insert nil value (key: %@)",    NSStringFromClass([self class]), NSStringFromSelector(_cmd), aKey]; }
+  
+  _JKDictionaryResizeIfNeccessary(self);
+#ifndef __clang_analyzer__
+  aKey     = [aKey     copy];   // Why on earth would clang complain that this -copy "might leak", 
+  anObject = [anObject retain]; // but this -retain doesn't!?
+#endif // __clang_analyzer__
+  _JKDictionaryAddObject(self, CFHash(aKey), aKey, anObject);
+  mutations = (mutations == NSUIntegerMax) ? 1UL : mutations + 1UL;
+}
+
+- (void)removeObjectForKey:(id)aKey
+{
+  if(mutations == 0UL)  { [NSException raise:NSInternalInconsistencyException format:@"*** -[%@ %@]: mutating method sent to immutable object", NSStringFromClass([self class]), NSStringFromSelector(_cmd)]; }
+  if(aKey      == NULL) { [NSException raise:NSInvalidArgumentException       format:@"*** -[%@ %@]: attempt to remove nil key",                NSStringFromClass([self class]), NSStringFromSelector(_cmd)]; }
+  JKHashTableEntry *entryForKey = _JKDictionaryHashTableEntryForKey(self, aKey);
+  if(entryForKey != NULL) {
+    _JKDictionaryRemoveObjectWithEntry(self, entryForKey);
+    mutations = (mutations == NSUIntegerMax) ? 1UL : mutations + 1UL;
+  }
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+  NSParameterAssert((entry != NULL) && (count <= capacity));
+  return((mutations == 0UL) ? [self retain] : [[NSDictionary allocWithZone:zone] initWithDictionary:self]);
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone
+{
+  NSParameterAssert((entry != NULL) && (count <= capacity));
+  return([[NSMutableDictionary allocWithZone:zone] initWithDictionary:self]);
+}
+
+@end
+
+
+
+#pragma mark -
+
+JK_STATIC_INLINE size_t jk_min(size_t a, size_t b) { return((a < b) ? a : b); }
+JK_STATIC_INLINE size_t jk_max(size_t a, size_t b) { return((a > b) ? a : b); }
+
+JK_STATIC_INLINE JKHash calculateHash(JKHash currentHash, unsigned char c) { return(((currentHash << 5) + currentHash) + c); }
+
+static void jk_error(JKParseState *parseState, NSString *format, ...) {
+  NSCParameterAssert((parseState != NULL) && (format != NULL));
+
+  va_list varArgsList;
+  va_start(varArgsList, format);
+  NSString *formatString = [[[NSString alloc] initWithFormat:format arguments:varArgsList] autorelease];
+  va_end(varArgsList);
+
+#if 0
+  const unsigned char *lineStart      = parseState->stringBuffer.bytes.ptr + parseState->lineStartIndex;
+  const unsigned char *lineEnd        = lineStart;
+  const unsigned char *atCharacterPtr = NULL;
+
+  for(atCharacterPtr = lineStart; atCharacterPtr < JK_END_STRING_PTR(parseState); atCharacterPtr++) { lineEnd = atCharacterPtr; if(jk_parse_is_newline(parseState, atCharacterPtr)) { break; } }
+
+  NSString *lineString = @"", *carretString = @"";
+  if(lineStart < JK_END_STRING_PTR(parseState)) {
+    lineString   = [[[NSString alloc] initWithBytes:lineStart length:(lineEnd - lineStart) encoding:NSUTF8StringEncoding] autorelease];
+    carretString = [NSString stringWithFormat:@"%*.*s^", (int)(parseState->atIndex - parseState->lineStartIndex), (int)(parseState->atIndex - parseState->lineStartIndex), " "];
+  }
+#endif
+
+  if(parseState->error == NULL) {
+    parseState->error = [NSError errorWithDomain:@"JKErrorDomain" code:-1L userInfo:
+                                   [NSDictionary dictionaryWithObjectsAndKeys:
+                                                                              formatString,                                             NSLocalizedDescriptionKey,
+                                                                              [NSNumber numberWithUnsignedLong:parseState->atIndex],    @"JKAtIndexKey",
+                                                                              [NSNumber numberWithUnsignedLong:parseState->lineNumber], @"JKLineNumberKey",
+                                                 //lineString,   @"JKErrorLine0Key",
+                                                 //carretString, @"JKErrorLine1Key",
+                                                                              NULL]];
+  }
+}
+
+#pragma mark -
+#pragma mark Buffer and Object Stack management functions
+
+static void jk_managedBuffer_release(JKManagedBuffer *managedBuffer) {
+  if((managedBuffer->flags & JKManagedBufferMustFree)) {
+    if(managedBuffer->bytes.ptr != NULL) { free(managedBuffer->bytes.ptr); managedBuffer->bytes.ptr = NULL; }
+    managedBuffer->flags &= ~JKManagedBufferMustFree;
+  }
+
+  managedBuffer->bytes.ptr     = NULL;
+  managedBuffer->bytes.length  = 0UL;
+  managedBuffer->flags        &= ~JKManagedBufferLocationMask;
+}
+
+static void jk_managedBuffer_setToStackBuffer(JKManagedBuffer *managedBuffer, unsigned char *ptr, size_t length) {
+  jk_managedBuffer_release(managedBuffer);
+  managedBuffer->bytes.ptr     = ptr;
+  managedBuffer->bytes.length  = length;
+  managedBuffer->flags         = (managedBuffer->flags & ~JKManagedBufferLocationMask) | JKManagedBufferOnStack;
+}
+
+static unsigned char *jk_managedBuffer_resize(JKManagedBuffer *managedBuffer, size_t newSize) {
+  size_t roundedUpNewSize = newSize;
+
+  if(managedBuffer->roundSizeUpToMultipleOf > 0UL) { roundedUpNewSize = newSize + ((managedBuffer->roundSizeUpToMultipleOf - (newSize % managedBuffer->roundSizeUpToMultipleOf)) % managedBuffer->roundSizeUpToMultipleOf); }
+
+  if((roundedUpNewSize != managedBuffer->bytes.length) && (roundedUpNewSize > managedBuffer->bytes.length)) {
+    if((managedBuffer->flags & JKManagedBufferLocationMask) == JKManagedBufferOnStack) {
+      NSCParameterAssert((managedBuffer->flags & JKManagedBufferMustFree) == 0);
+      unsigned char *newBuffer = NULL, *oldBuffer = managedBuffer->bytes.ptr;
+      
+      if((newBuffer = (unsigned char *)malloc(roundedUpNewSize)) == NULL) { return(NULL); }
+      memcpy(newBuffer, oldBuffer, jk_min(managedBuffer->bytes.length, roundedUpNewSize));
+      managedBuffer->flags        = (managedBuffer->flags & ~JKManagedBufferLocationMask) | (JKManagedBufferOnHeap | JKManagedBufferMustFree);
+      managedBuffer->bytes.ptr    = newBuffer;
+      managedBuffer->bytes.length = roundedUpNewSize;
+    } else {
+      NSCParameterAssert(((managedBuffer->flags & JKManagedBufferMustFree) != 0) && ((managedBuffer->flags & JKManagedBufferLocationMask) == JKManagedBufferOnHeap));
+      if((managedBuffer->bytes.ptr = (unsigned char *)reallocf(managedBuffer->bytes.ptr, roundedUpNewSize)) == NULL) { return(NULL); }
+      managedBuffer->bytes.length = roundedUpNewSize;
+    }
+  }
+
+  return(managedBuffer->bytes.ptr);
+}
+
+
+
+static void jk_objectStack_release(JKObjectStack *objectStack) {
+  NSCParameterAssert(objectStack != NULL);
+
+  NSCParameterAssert(objectStack->index <= objectStack->count);
+  size_t atIndex = 0UL;
+  for(atIndex = 0UL; atIndex < objectStack->index; atIndex++) {
+    if(objectStack->objects[atIndex] != NULL) { CFRelease(objectStack->objects[atIndex]); objectStack->objects[atIndex] = NULL; }
+    if(objectStack->keys[atIndex]    != NULL) { CFRelease(objectStack->keys[atIndex]);    objectStack->keys[atIndex]    = NULL; }
+  }
+  objectStack->index = 0UL;
+
+  if(objectStack->flags & JKObjectStackMustFree) {
+    NSCParameterAssert((objectStack->flags & JKObjectStackLocationMask) == JKObjectStackOnHeap);
+    if(objectStack->objects  != NULL) { free(objectStack->objects);  objectStack->objects  = NULL; }
+    if(objectStack->keys     != NULL) { free(objectStack->keys);     objectStack->keys     = NULL; }
+    if(objectStack->cfHashes != NULL) { free(objectStack->cfHashes); objectStack->cfHashes = NULL; }
+    objectStack->flags &= ~JKObjectStackMustFree;
+  }
+
+  objectStack->objects  = NULL;
+  objectStack->keys     = NULL;
+  objectStack->cfHashes = NULL;
+
+  objectStack->count    = 0UL;
+  objectStack->flags   &= ~JKObjectStackLocationMask;
+}
+
+static void jk_objectStack_setToStackBuffer(JKObjectStack *objectStack, void **objects, void **keys, CFHashCode *cfHashes, size_t count) {
+  NSCParameterAssert((objectStack != NULL) && (objects != NULL) && (keys != NULL) && (cfHashes != NULL) && (count > 0UL));
+  jk_objectStack_release(objectStack);
+  objectStack->objects  = objects;
+  objectStack->keys     = keys;
+  objectStack->cfHashes = cfHashes;
+  objectStack->count    = count;
+  objectStack->flags    = (objectStack->flags & ~JKObjectStackLocationMask) | JKObjectStackOnStack;
+#ifndef NS_BLOCK_ASSERTIONS
+  size_t idx;
+  for(idx = 0UL; idx < objectStack->count; idx++) { objectStack->objects[idx] = NULL; objectStack->keys[idx] = NULL; objectStack->cfHashes[idx] = 0UL; }
+#endif
+}
+
+static int jk_objectStack_resize(JKObjectStack *objectStack, size_t newCount) {
+  size_t roundedUpNewCount = newCount;
+  int    returnCode = 0;
+
+  void       **newObjects  = NULL, **newKeys = NULL;
+  CFHashCode  *newCFHashes = NULL;
+
+  if(objectStack->roundSizeUpToMultipleOf > 0UL) { roundedUpNewCount = newCount + ((objectStack->roundSizeUpToMultipleOf - (newCount % objectStack->roundSizeUpToMultipleOf)) % objectStack->roundSizeUpToMultipleOf); }
+
+  if((roundedUpNewCount != objectStack->count) && (roundedUpNewCount > objectStack->count)) {
+    if((objectStack->flags & JKObjectStackLocationMask) == JKObjectStackOnStack) {
+      NSCParameterAssert((objectStack->flags & JKObjectStackMustFree) == 0);
+
+      if((newObjects  = (void **     )calloc(1UL, roundedUpNewCount * sizeof(void *    ))) == NULL) { returnCode = 1; goto errorExit; }
+      memcpy(newObjects, objectStack->objects,   jk_min(objectStack->count, roundedUpNewCount) * sizeof(void *));
+      if((newKeys     = (void **     )calloc(1UL, roundedUpNewCount * sizeof(void *    ))) == NULL) { returnCode = 1; goto errorExit; }
+      memcpy(newKeys,     objectStack->keys,     jk_min(objectStack->count, roundedUpNewCount) * sizeof(void *));
+
+      if((newCFHashes = (CFHashCode *)calloc(1UL, roundedUpNewCount * sizeof(CFHashCode))) == NULL) { returnCode = 1; goto errorExit; }
+      memcpy(newCFHashes, objectStack->cfHashes, jk_min(objectStack->count, roundedUpNewCount) * sizeof(CFHashCode));
+
+      objectStack->flags    = (objectStack->flags & ~JKObjectStackLocationMask) | (JKObjectStackOnHeap | JKObjectStackMustFree);
+      objectStack->objects  = newObjects;  newObjects  = NULL;
+      objectStack->keys     = newKeys;     newKeys     = NULL;
+      objectStack->cfHashes = newCFHashes; newCFHashes = NULL;
+      objectStack->count    = roundedUpNewCount;
+    } else {
+      NSCParameterAssert(((objectStack->flags & JKObjectStackMustFree) != 0) && ((objectStack->flags & JKObjectStackLocationMask) == JKObjectStackOnHeap));
+      if((newObjects  = (void  **    )realloc(objectStack->objects,  roundedUpNewCount * sizeof(void *    ))) != NULL) { objectStack->objects  = newObjects;  newObjects  = NULL; } else { returnCode = 1; goto errorExit; }
+      if((newKeys     = (void  **    )realloc(objectStack->keys,     roundedUpNewCount * sizeof(void *    ))) != NULL) { objectStack->keys     = newKeys;     newKeys     = NULL; } else { returnCode = 1; goto errorExit; }
+      if((newCFHashes = (CFHashCode *)realloc(objectStack->cfHashes, roundedUpNewCount * sizeof(CFHashCode))) != NULL) { objectStack->cfHashes = newCFHashes; newCFHashes = NULL; } else { returnCode = 1; goto errorExit; }
+
+#ifndef NS_BLOCK_ASSERTIONS
+      size_t idx;
+      for(idx = objectStack->count; idx < roundedUpNewCount; idx++) { objectStack->objects[idx] = NULL; objectStack->keys[idx] = NULL; objectStack->cfHashes[idx] = 0UL; }
+#endif
+      objectStack->count = roundedUpNewCount;
+    }
+  }
+
+ errorExit:
+  if(newObjects  != NULL) { free(newObjects);  newObjects  = NULL; }
+  if(newKeys     != NULL) { free(newKeys);     newKeys     = NULL; }
+  if(newCFHashes != NULL) { free(newCFHashes); newCFHashes = NULL; }
+
+  return(returnCode);
+}
+
+////////////
+#pragma mark -
+#pragma mark Unicode related functions
+
+JK_STATIC_INLINE ConversionResult isValidCodePoint(UTF32 *u32CodePoint) {
+  ConversionResult result = conversionOK;
+  UTF32            ch     = *u32CodePoint;
+
+  if(JK_EXPECT_F(ch >= UNI_SUR_HIGH_START) && (JK_EXPECT_T(ch <= UNI_SUR_LOW_END)))                                                        { result = sourceIllegal; ch = UNI_REPLACEMENT_CHAR; goto finished; }
+  if(JK_EXPECT_F(ch >= 0xFDD0U) && (JK_EXPECT_F(ch <= 0xFDEFU) || JK_EXPECT_F((ch & 0xFFFEU) == 0xFFFEU)) && JK_EXPECT_T(ch <= 0x10FFFFU)) { result = sourceIllegal; ch = UNI_REPLACEMENT_CHAR; goto finished; }
+  if(JK_EXPECT_F(ch == 0U))                                                                                                                { result = sourceIllegal; ch = UNI_REPLACEMENT_CHAR; goto finished; }
+
+ finished:
+  *u32CodePoint = ch;
+  return(result);
+}
+
+
+static int isLegalUTF8(const UTF8 *source, size_t length) {
+  const UTF8 *srcptr = source + length;
+  UTF8 a;
+
+  switch(length) {
+    default: return(0); // Everything else falls through when "true"...
+    case 4: if(JK_EXPECT_F(((a = (*--srcptr)) < 0x80) || (a > 0xBF))) { return(0); }
+    case 3: if(JK_EXPECT_F(((a = (*--srcptr)) < 0x80) || (a > 0xBF))) { return(0); }
+    case 2: if(JK_EXPECT_F( (a = (*--srcptr)) > 0xBF               )) { return(0); }
+      
+      switch(*source) { // no fall-through in this inner switch
+        case 0xE0: if(JK_EXPECT_F(a < 0xA0)) { return(0); } break;
+        case 0xED: if(JK_EXPECT_F(a > 0x9F)) { return(0); } break;
+        case 0xF0: if(JK_EXPECT_F(a < 0x90)) { return(0); } break;
+        case 0xF4: if(JK_EXPECT_F(a > 0x8F)) { return(0); } break;
+        default:   if(JK_EXPECT_F(a < 0x80)) { return(0); }
+      }
+      
+    case 1: if(JK_EXPECT_F((JK_EXPECT_T(*source < 0xC2)) && JK_EXPECT_F(*source >= 0x80))) { return(0); }
+  }
+
+  if(JK_EXPECT_F(*source > 0xF4)) { return(0); }
+
+  return(1);
+}
+
+static ConversionResult ConvertSingleCodePointInUTF8(const UTF8 *sourceStart, const UTF8 *sourceEnd, UTF8 const **nextUTF8, UTF32 *convertedUTF32) {
+  ConversionResult result = conversionOK;
+  const UTF8 *source = sourceStart;
+  UTF32 ch = 0UL;
+
+#if !defined(JK_FAST_TRAILING_BYTES)
+  unsigned short extraBytesToRead = trailingBytesForUTF8[*source];
+#else
+  unsigned short extraBytesToRead = __builtin_clz(((*source)^0xff) << 25);
+#endif
+
+  if(JK_EXPECT_F((source + extraBytesToRead + 1) > sourceEnd) || JK_EXPECT_F(!isLegalUTF8(source, extraBytesToRead + 1))) {
+    source++;
+    while((source < sourceEnd) && (((*source) & 0xc0) == 0x80) && ((source - sourceStart) < (extraBytesToRead + 1))) { source++; } 
+    NSCParameterAssert(source <= sourceEnd);
+    result = ((source < sourceEnd) && (((*source) & 0xc0) != 0x80)) ? sourceIllegal : ((sourceStart + extraBytesToRead + 1) > sourceEnd) ? sourceExhausted : sourceIllegal;
+    ch = UNI_REPLACEMENT_CHAR;
+    goto finished;
+  }
+
+  switch(extraBytesToRead) { // The cases all fall through.
+    case 5: ch += *source++; ch <<= 6;
+    case 4: ch += *source++; ch <<= 6;
+    case 3: ch += *source++; ch <<= 6;
+    case 2: ch += *source++; ch <<= 6;
+    case 1: ch += *source++; ch <<= 6;
+    case 0: ch += *source++;
+  }
+  ch -= offsetsFromUTF8[extraBytesToRead];
+
+  result = isValidCodePoint(&ch);
+  
+ finished:
+  *nextUTF8       = source;
+  *convertedUTF32 = ch;
+  
+  return(result);
+}
+
+
+static ConversionResult ConvertUTF32toUTF8 (UTF32 u32CodePoint, UTF8 **targetStart, UTF8 *targetEnd) {
+  const UTF32       byteMask     = 0xBF, byteMark = 0x80;
+  ConversionResult  result       = conversionOK;
+  UTF8             *target       = *targetStart;
+  UTF32             ch           = u32CodePoint;
+  unsigned short    bytesToWrite = 0;
+
+  result = isValidCodePoint(&ch);
+
+  // Figure out how many bytes the result will require. Turn any illegally large UTF32 things (> Plane 17) into replacement chars.
+       if(ch < (UTF32)0x80)          { bytesToWrite = 1; }
+  else if(ch < (UTF32)0x800)         { bytesToWrite = 2; }
+  else if(ch < (UTF32)0x10000)       { bytesToWrite = 3; }
+  else if(ch <= UNI_MAX_LEGAL_UTF32) { bytesToWrite = 4; }
+  else {                               bytesToWrite = 3; ch = UNI_REPLACEMENT_CHAR; result = sourceIllegal; }
+        
+  target += bytesToWrite;
+  if (target > targetEnd) { target -= bytesToWrite; result = targetExhausted; goto finished; }
+
+  switch (bytesToWrite) { // note: everything falls through.
+    case 4: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+    case 3: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+    case 2: *--target = (UTF8)((ch | byteMark) & byteMask); ch >>= 6;
+    case 1: *--target = (UTF8) (ch | firstByteMark[bytesToWrite]);
+  }
+
+  target += bytesToWrite;
+
+ finished:
+  *targetStart = target;
+  return(result);
+}
+
+JK_STATIC_INLINE int jk_string_add_unicodeCodePoint(JKParseState *parseState, uint32_t unicodeCodePoint, size_t *tokenBufferIdx, JKHash *stringHash) {
+  UTF8             *u8s = &parseState->token.tokenBuffer.bytes.ptr[*tokenBufferIdx];
+  ConversionResult  result;
+
+  if((result = ConvertUTF32toUTF8(unicodeCodePoint, &u8s, (parseState->token.tokenBuffer.bytes.ptr + parseState->token.tokenBuffer.bytes.length))) != conversionOK) { if(result == targetExhausted) { return(1); } }
+  size_t utf8len = u8s - &parseState->token.tokenBuffer.bytes.ptr[*tokenBufferIdx], nextIdx = (*tokenBufferIdx) + utf8len;
+  
+  while(*tokenBufferIdx < nextIdx) { *stringHash = calculateHash(*stringHash, parseState->token.tokenBuffer.bytes.ptr[(*tokenBufferIdx)++]); }
+
+  return(0);
+}
+
+////////////
+#pragma mark -
+#pragma mark Decoding / parsing / deserializing functions
+
+static int jk_parse_string(JKParseState *parseState) {
+  NSCParameterAssert((parseState != NULL) && (JK_AT_STRING_PTR(parseState) <= JK_END_STRING_PTR(parseState)));
+  const unsigned char *stringStart       = JK_AT_STRING_PTR(parseState) + 1;
+  const unsigned char *endOfBuffer       = JK_END_STRING_PTR(parseState);
+  const unsigned char *atStringCharacter = stringStart;
+  unsigned char       *tokenBuffer       = parseState->token.tokenBuffer.bytes.ptr;
+  size_t               tokenStartIndex   = parseState->atIndex;
+  size_t               tokenBufferIdx    = 0UL;
+
+  int      onlySimpleString        = 1,  stringState     = JSONStringStateStart;
+  uint16_t escapedUnicode1         = 0U, escapedUnicode2 = 0U;
+  uint32_t escapedUnicodeCodePoint = 0U;
+  JKHash   stringHash              = JK_HASH_INIT;
+    
+  while(1) {
+    unsigned long currentChar;
+
+    if(JK_EXPECT_F(atStringCharacter == endOfBuffer)) { /* XXX Add error message */ stringState = JSONStringStateError; goto finishedParsing; }
+    
+    if(JK_EXPECT_F((currentChar = *atStringCharacter++) >= 0x80UL)) {
+      const unsigned char *nextValidCharacter = NULL;
+      UTF32                u32ch              = 0U;
+      ConversionResult     result;
+
+      if(JK_EXPECT_F((result = ConvertSingleCodePointInUTF8(atStringCharacter - 1, endOfBuffer, (UTF8 const **)&nextValidCharacter, &u32ch)) != conversionOK)) { goto switchToSlowPath; }
+      stringHash = calculateHash(stringHash, currentChar);
+      while(atStringCharacter < nextValidCharacter) { NSCParameterAssert(JK_AT_STRING_PTR(parseState) <= JK_END_STRING_PTR(parseState)); stringHash = calculateHash(stringHash, *atStringCharacter++); }
+      continue;
+    } else {
+      if(JK_EXPECT_F(currentChar == (unsigned long)'"')) { stringState = JSONStringStateFinished; goto finishedParsing; }
+
+      if(JK_EXPECT_F(currentChar == (unsigned long)'\\')) {
+      switchToSlowPath:
+        onlySimpleString = 0;
+        stringState      = JSONStringStateParsing;
+        tokenBufferIdx   = (atStringCharacter - stringStart) - 1L;
+        if(JK_EXPECT_F((tokenBufferIdx + 16UL) > parseState->token.tokenBuffer.bytes.length)) { if((tokenBuffer = jk_managedBuffer_resize(&parseState->token.tokenBuffer, tokenBufferIdx + 1024UL)) == NULL) { jk_error(parseState, @"Internal error: Unable to resize temporary buffer. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; } }
+        memcpy(tokenBuffer, stringStart, tokenBufferIdx);
+        goto slowMatch;
+      }
+
+      if(JK_EXPECT_F(currentChar < 0x20UL)) { jk_error(parseState, @"Invalid character < 0x20 found in string: 0x%2.2x.", currentChar); stringState = JSONStringStateError; goto finishedParsing; }
+
+      stringHash = calculateHash(stringHash, currentChar);
+    }
+  }
+
+ slowMatch:
+
+  for(atStringCharacter = (stringStart + ((atStringCharacter - stringStart) - 1L)); (atStringCharacter < endOfBuffer) && (tokenBufferIdx < parseState->token.tokenBuffer.bytes.length); atStringCharacter++) {
+    if((tokenBufferIdx + 16UL) > parseState->token.tokenBuffer.bytes.length) { if((tokenBuffer = jk_managedBuffer_resize(&parseState->token.tokenBuffer, tokenBufferIdx + 1024UL)) == NULL) { jk_error(parseState, @"Internal error: Unable to resize temporary buffer. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; } }
+
+    NSCParameterAssert(tokenBufferIdx < parseState->token.tokenBuffer.bytes.length);
+
+    unsigned long currentChar = (*atStringCharacter), escapedChar;
+
+    if(JK_EXPECT_T(stringState == JSONStringStateParsing)) {
+      if(JK_EXPECT_T(currentChar >= 0x20UL)) {
+        if(JK_EXPECT_T(currentChar < (unsigned long)0x80)) { // Not a UTF8 sequence
+          if(JK_EXPECT_F(currentChar == (unsigned long)'"'))  { stringState = JSONStringStateFinished; atStringCharacter++; goto finishedParsing; }
+          if(JK_EXPECT_F(currentChar == (unsigned long)'\\')) { stringState = JSONStringStateEscape; continue; }
+          stringHash = calculateHash(stringHash, currentChar);
+          tokenBuffer[tokenBufferIdx++] = currentChar;
+          continue;
+        } else { // UTF8 sequence
+          const unsigned char *nextValidCharacter = NULL;
+          UTF32                u32ch              = 0U;
+          ConversionResult     result;
+          
+          if(JK_EXPECT_F((result = ConvertSingleCodePointInUTF8(atStringCharacter, endOfBuffer, (UTF8 const **)&nextValidCharacter, &u32ch)) != conversionOK)) {
+            if((result == sourceIllegal) && ((parseState->parseOptionFlags & JKParseOptionLooseUnicode) == 0)) { jk_error(parseState, @"Illegal UTF8 sequence found in \"\" string.");              stringState = JSONStringStateError; goto finishedParsing; }
+            if(result == sourceExhausted)                                                                      { jk_error(parseState, @"End of buffer reached while parsing UTF8 in \"\" string."); stringState = JSONStringStateError; goto finishedParsing; }
+            if(jk_string_add_unicodeCodePoint(parseState, u32ch, &tokenBufferIdx, &stringHash))                { jk_error(parseState, @"Internal error: Unable to add UTF8 sequence to internal string buffer. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; }
+            atStringCharacter = nextValidCharacter - 1;
+            continue;
+          } else {
+            while(atStringCharacter < nextValidCharacter) { tokenBuffer[tokenBufferIdx++] = *atStringCharacter; stringHash = calculateHash(stringHash, *atStringCharacter++); }
+            atStringCharacter--;
+            continue;
+          }
+        }
+      } else { // currentChar < 0x20
+        jk_error(parseState, @"Invalid character < 0x20 found in string: 0x%2.2x.", currentChar); stringState = JSONStringStateError; goto finishedParsing;
+      }
+
+    } else { // stringState != JSONStringStateParsing
+      int isSurrogate = 1;
+
+      switch(stringState) {
+        case JSONStringStateEscape:
+          switch(currentChar) {
+            case 'u': escapedUnicode1 = 0U; escapedUnicode2 = 0U; escapedUnicodeCodePoint = 0U; stringState = JSONStringStateEscapedUnicode1; break;
+
+            case 'b':  escapedChar = '\b'; goto parsedEscapedChar;
+            case 'f':  escapedChar = '\f'; goto parsedEscapedChar;
+            case 'n':  escapedChar = '\n'; goto parsedEscapedChar;
+            case 'r':  escapedChar = '\r'; goto parsedEscapedChar;
+            case 't':  escapedChar = '\t'; goto parsedEscapedChar;
+            case '\\': escapedChar = '\\'; goto parsedEscapedChar;
+            case '/':  escapedChar = '/';  goto parsedEscapedChar;
+            case '"':  escapedChar = '"';  goto parsedEscapedChar;
+              
+            parsedEscapedChar:
+              stringState = JSONStringStateParsing;
+              stringHash  = calculateHash(stringHash, escapedChar);
+              tokenBuffer[tokenBufferIdx++] = escapedChar;
+              break;
+              
+            default: jk_error(parseState, @"Invalid escape sequence found in \"\" string."); stringState = JSONStringStateError; goto finishedParsing; break;
+          }
+          break;
+
+        case JSONStringStateEscapedUnicode1:
+        case JSONStringStateEscapedUnicode2:
+        case JSONStringStateEscapedUnicode3:
+        case JSONStringStateEscapedUnicode4:           isSurrogate = 0;
+        case JSONStringStateEscapedUnicodeSurrogate1:
+        case JSONStringStateEscapedUnicodeSurrogate2:
+        case JSONStringStateEscapedUnicodeSurrogate3:
+        case JSONStringStateEscapedUnicodeSurrogate4:
+          {
+            uint16_t hexValue = 0U;
+
+            switch(currentChar) {
+              case '0' ... '9': hexValue =  currentChar - '0';        goto parsedHex;
+              case 'a' ... 'f': hexValue = (currentChar - 'a') + 10U; goto parsedHex;
+              case 'A' ... 'F': hexValue = (currentChar - 'A') + 10U; goto parsedHex;
+                
+              parsedHex:
+              if(!isSurrogate) { escapedUnicode1 = (escapedUnicode1 << 4) | hexValue; } else { escapedUnicode2 = (escapedUnicode2 << 4) | hexValue; }
+                
+              if(stringState == JSONStringStateEscapedUnicode4) {
+                if(((escapedUnicode1 >= 0xD800U) && (escapedUnicode1 < 0xE000U))) {
+                  if((escapedUnicode1 >= 0xD800U) && (escapedUnicode1 < 0xDC00U)) { stringState = JSONStringStateEscapedNeedEscapeForSurrogate; }
+                  else if((escapedUnicode1 >= 0xDC00U) && (escapedUnicode1 < 0xE000U)) { 
+                    if((parseState->parseOptionFlags & JKParseOptionLooseUnicode)) { escapedUnicodeCodePoint = UNI_REPLACEMENT_CHAR; }
+                    else { jk_error(parseState, @"Illegal \\u Unicode escape sequence."); stringState = JSONStringStateError; goto finishedParsing; }
+                  }
+                }
+                else { escapedUnicodeCodePoint = escapedUnicode1; }
+              }
+
+              if(stringState == JSONStringStateEscapedUnicodeSurrogate4) {
+                if((escapedUnicode2 < 0xdc00) || (escapedUnicode2 > 0xdfff)) {
+                  if((parseState->parseOptionFlags & JKParseOptionLooseUnicode)) { escapedUnicodeCodePoint = UNI_REPLACEMENT_CHAR; }
+                  else { jk_error(parseState, @"Illegal \\u Unicode escape sequence."); stringState = JSONStringStateError; goto finishedParsing; }
+                }
+                else { escapedUnicodeCodePoint = ((escapedUnicode1 - 0xd800) * 0x400) + (escapedUnicode2 - 0xdc00) + 0x10000; }
+              }
+                
+              if((stringState == JSONStringStateEscapedUnicode4) || (stringState == JSONStringStateEscapedUnicodeSurrogate4)) { 
+                if((isValidCodePoint(&escapedUnicodeCodePoint) == sourceIllegal) && ((parseState->parseOptionFlags & JKParseOptionLooseUnicode) == 0)) { jk_error(parseState, @"Illegal \\u Unicode escape sequence."); stringState = JSONStringStateError; goto finishedParsing; }
+                stringState = JSONStringStateParsing;
+                if(jk_string_add_unicodeCodePoint(parseState, escapedUnicodeCodePoint, &tokenBufferIdx, &stringHash)) { jk_error(parseState, @"Internal error: Unable to add UTF8 sequence to internal string buffer. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; }
+              }
+              else if((stringState >= JSONStringStateEscapedUnicode1) && (stringState <= JSONStringStateEscapedUnicodeSurrogate4)) { stringState++; }
+              break;
+
+              default: jk_error(parseState, @"Unexpected character found in \\u Unicode escape sequence.  Found '%c', expected [0-9a-fA-F].", currentChar); stringState = JSONStringStateError; goto finishedParsing; break;
+            }
+          }
+          break;
+
+        case JSONStringStateEscapedNeedEscapeForSurrogate:
+          if(currentChar == '\\') { stringState = JSONStringStateEscapedNeedEscapedUForSurrogate; }
+          else { 
+            if((parseState->parseOptionFlags & JKParseOptionLooseUnicode) == 0) { jk_error(parseState, @"Required a second \\u Unicode escape sequence following a surrogate \\u Unicode escape sequence."); stringState = JSONStringStateError; goto finishedParsing; }
+            else { stringState = JSONStringStateParsing; atStringCharacter--;    if(jk_string_add_unicodeCodePoint(parseState, UNI_REPLACEMENT_CHAR, &tokenBufferIdx, &stringHash)) { jk_error(parseState, @"Internal error: Unable to add UTF8 sequence to internal string buffer. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; } }
+          }
+          break;
+
+        case JSONStringStateEscapedNeedEscapedUForSurrogate:
+          if(currentChar == 'u') { stringState = JSONStringStateEscapedUnicodeSurrogate1; }
+          else { 
+            if((parseState->parseOptionFlags & JKParseOptionLooseUnicode) == 0) { jk_error(parseState, @"Required a second \\u Unicode escape sequence following a surrogate \\u Unicode escape sequence."); stringState = JSONStringStateError; goto finishedParsing; }
+            else { stringState = JSONStringStateParsing; atStringCharacter -= 2; if(jk_string_add_unicodeCodePoint(parseState, UNI_REPLACEMENT_CHAR, &tokenBufferIdx, &stringHash)) { jk_error(parseState, @"Internal error: Unable to add UTF8 sequence to internal string buffer. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; } }
+          }
+          break;
+
+        default: jk_error(parseState, @"Internal error: Unknown stringState. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); stringState = JSONStringStateError; goto finishedParsing; break;
+      }
+    }
+  }
+
+finishedParsing:
+
+  if(JK_EXPECT_T(stringState == JSONStringStateFinished)) {
+    NSCParameterAssert((parseState->stringBuffer.bytes.ptr + tokenStartIndex) < atStringCharacter);
+
+    parseState->token.tokenPtrRange.ptr    = parseState->stringBuffer.bytes.ptr + tokenStartIndex;
+    parseState->token.tokenPtrRange.length = (atStringCharacter - parseState->token.tokenPtrRange.ptr);
+
+    if(JK_EXPECT_T(onlySimpleString)) {
+      NSCParameterAssert(((parseState->token.tokenPtrRange.ptr + 1) < endOfBuffer) && (parseState->token.tokenPtrRange.length >= 2UL) && (((parseState->token.tokenPtrRange.ptr + 1) + (parseState->token.tokenPtrRange.length - 2)) < endOfBuffer));
+      parseState->token.value.ptrRange.ptr    = parseState->token.tokenPtrRange.ptr    + 1;
+      parseState->token.value.ptrRange.length = parseState->token.tokenPtrRange.length - 2UL;
+    } else {
+      parseState->token.value.ptrRange.ptr    = parseState->token.tokenBuffer.bytes.ptr;
+      parseState->token.value.ptrRange.length = tokenBufferIdx;
+    }
+    
+    parseState->token.value.hash = stringHash;
+    parseState->token.value.type = JKValueTypeString;
+    parseState->atIndex          = (atStringCharacter - parseState->stringBuffer.bytes.ptr);
+  }
+
+  if(JK_EXPECT_F(stringState != JSONStringStateFinished)) { jk_error(parseState, @"Invalid string."); }
+  return(JK_EXPECT_T(stringState == JSONStringStateFinished) ? 0 : 1);
+}
+
+static int jk_parse_number(JKParseState *parseState) {
+  NSCParameterAssert((parseState != NULL) && (JK_AT_STRING_PTR(parseState) <= JK_END_STRING_PTR(parseState)));
+  const unsigned char *numberStart       = JK_AT_STRING_PTR(parseState);
+  const unsigned char *endOfBuffer       = JK_END_STRING_PTR(parseState);
+  const unsigned char *atNumberCharacter = NULL;
+  int                  numberState       = JSONNumberStateWholeNumberStart, isFloatingPoint = 0, isNegative = 0, backup = 0;
+  size_t               startingIndex     = parseState->atIndex;
+  
+  for(atNumberCharacter = numberStart; (JK_EXPECT_T(atNumberCharacter < endOfBuffer)) && (JK_EXPECT_T(!(JK_EXPECT_F(numberState == JSONNumberStateFinished) || JK_EXPECT_F(numberState == JSONNumberStateError)))); atNumberCharacter++) {
+    unsigned long currentChar = (unsigned long)(*atNumberCharacter), lowerCaseCC = currentChar | 0x20UL;
+    
+    switch(numberState) {
+      case JSONNumberStateWholeNumberStart: if   (currentChar == '-')                                                                              { numberState = JSONNumberStateWholeNumberMinus;      isNegative      = 1; break; }
+      case JSONNumberStateWholeNumberMinus: if   (currentChar == '0')                                                                              { numberState = JSONNumberStateWholeNumberZero;                            break; }
+                                       else if(  (currentChar >= '1') && (currentChar <= '9'))                                                     { numberState = JSONNumberStateWholeNumber;                                break; }
+                                       else                                                     { /* XXX Add error message */                        numberState = JSONNumberStateError;                                      break; }
+      case JSONNumberStateExponentStart:    if(  (currentChar == '+') || (currentChar == '-'))                                                     { numberState = JSONNumberStateExponentPlusMinus;                          break; }
+      case JSONNumberStateFractionalNumberStart:
+      case JSONNumberStateExponentPlusMinus:if(!((currentChar >= '0') && (currentChar <= '9'))) { /* XXX Add error message */                        numberState = JSONNumberStateError;                                      break; }
+                                       else {                                              if(numberState == JSONNumberStateFractionalNumberStart) { numberState = JSONNumberStateFractionalNumber; }
+                                                                                           else                                                    { numberState = JSONNumberStateExponent;         }                         break; }
+      case JSONNumberStateWholeNumberZero:
+      case JSONNumberStateWholeNumber:      if   (currentChar == '.')                                                                              { numberState = JSONNumberStateFractionalNumberStart; isFloatingPoint = 1; break; }
+      case JSONNumberStateFractionalNumber: if   (lowerCaseCC == 'e')                                                                              { numberState = JSONNumberStateExponentStart;         isFloatingPoint = 1; break; }
+      case JSONNumberStateExponent:         if(!((currentChar >= '0') && (currentChar <= '9')) || (numberState == JSONNumberStateWholeNumberZero)) { numberState = JSONNumberStateFinished;              backup          = 1; break; }
+        break;
+      default:                                                                                    /* XXX Add error message */                        numberState = JSONNumberStateError;                                      break;
+    }
+  }
+  
+  parseState->token.tokenPtrRange.ptr    = parseState->stringBuffer.bytes.ptr + startingIndex;
+  parseState->token.tokenPtrRange.length = (atNumberCharacter - parseState->token.tokenPtrRange.ptr) - backup;
+  parseState->atIndex                    = (parseState->token.tokenPtrRange.ptr + parseState->token.tokenPtrRange.length) - parseState->stringBuffer.bytes.ptr;
+
+  if(JK_EXPECT_T(numberState == JSONNumberStateFinished)) {
+    unsigned char  numberTempBuf[parseState->token.tokenPtrRange.length + 4UL];
+    unsigned char *endOfNumber = NULL;
+
+    memcpy(numberTempBuf, parseState->token.tokenPtrRange.ptr, parseState->token.tokenPtrRange.length);
+    numberTempBuf[parseState->token.tokenPtrRange.length] = 0;
+
+    errno = 0;
+    
+    // Treat "-0" as a floating point number, which is capable of representing negative zeros.
+    if(JK_EXPECT_F(parseState->token.tokenPtrRange.length == 2UL) && JK_EXPECT_F(numberTempBuf[1] == '0') && JK_EXPECT_F(isNegative)) { isFloatingPoint = 1; }
+
+    if(isFloatingPoint) {
+      parseState->token.value.number.doubleValue = strtod((const char *)numberTempBuf, (char **)&endOfNumber); // strtod is documented to return U+2261 (identical to) 0.0 on an underflow error (along with setting errno to ERANGE).
+      parseState->token.value.type               = JKValueTypeDouble;
+      parseState->token.value.ptrRange.ptr       = (const unsigned char *)&parseState->token.value.number.doubleValue;
+      parseState->token.value.ptrRange.length    = sizeof(double);
+      parseState->token.value.hash               = (JK_HASH_INIT + parseState->token.value.type);
+    } else {
+      if(isNegative) {
+        parseState->token.value.number.longLongValue = strtoll((const char *)numberTempBuf, (char **)&endOfNumber, 10);
+        parseState->token.value.type                 = JKValueTypeLongLong;
+        parseState->token.value.ptrRange.ptr         = (const unsigned char *)&parseState->token.value.number.longLongValue;
+        parseState->token.value.ptrRange.length      = sizeof(long long);
+        parseState->token.value.hash                 = (JK_HASH_INIT + parseState->token.value.type) + (JKHash)parseState->token.value.number.longLongValue;
+      } else {
+        parseState->token.value.number.unsignedLongLongValue = strtoull((const char *)numberTempBuf, (char **)&endOfNumber, 10);
+        parseState->token.value.type                         = JKValueTypeUnsignedLongLong;
+        parseState->token.value.ptrRange.ptr                 = (const unsigned char *)&parseState->token.value.number.unsignedLongLongValue;
+        parseState->token.value.ptrRange.length              = sizeof(unsigned long long);
+        parseState->token.value.hash                         = (JK_HASH_INIT + parseState->token.value.type) + (JKHash)parseState->token.value.number.unsignedLongLongValue;
+      }
+    }
+
+    if(JK_EXPECT_F(errno != 0)) {
+      numberState = JSONNumberStateError;
+      if(errno == ERANGE) {
+        switch(parseState->token.value.type) {
+          case JKValueTypeDouble:           jk_error(parseState, @"The value '%s' could not be represented as a 'double' due to %s.",           numberTempBuf, (parseState->token.value.number.doubleValue == 0.0) ? "underflow" : "overflow"); break; // see above for == 0.0.
+          case JKValueTypeLongLong:         jk_error(parseState, @"The value '%s' exceeded the minimum value that could be represented: %lld.", numberTempBuf, parseState->token.value.number.longLongValue);                                   break;
+          case JKValueTypeUnsignedLongLong: jk_error(parseState, @"The value '%s' exceeded the maximum value that could be represented: %llu.", numberTempBuf, parseState->token.value.number.unsignedLongLongValue);                           break;
+          default:                          jk_error(parseState, @"Internal error: Unknown token value type. %@ line #%ld",                     [NSString stringWithUTF8String:__FILE__], (long)__LINE__);                                      break;
+        }
+      }
+    }
+    if(JK_EXPECT_F(endOfNumber != &numberTempBuf[parseState->token.tokenPtrRange.length]) && JK_EXPECT_F(numberState != JSONNumberStateError)) { numberState = JSONNumberStateError; jk_error(parseState, @"The conversion function did not consume all of the number tokens characters."); }
+
+    size_t hashIndex = 0UL;
+    for(hashIndex = 0UL; hashIndex < parseState->token.value.ptrRange.length; hashIndex++) { parseState->token.value.hash = calculateHash(parseState->token.value.hash, parseState->token.value.ptrRange.ptr[hashIndex]); }
+  }
+
+  if(JK_EXPECT_F(numberState != JSONNumberStateFinished)) { jk_error(parseState, @"Invalid number."); }
+  return(JK_EXPECT_T((numberState == JSONNumberStateFinished)) ? 0 : 1);
+}
+
+JK_STATIC_INLINE void jk_set_parsed_token(JKParseState *parseState, const unsigned char *ptr, size_t length, JKTokenType type, size_t advanceBy) {
+  parseState->token.tokenPtrRange.ptr     = ptr;
+  parseState->token.tokenPtrRange.length  = length;
+  parseState->token.type                  = type;
+  parseState->atIndex                    += advanceBy;
+}
+
+static size_t jk_parse_is_newline(JKParseState *parseState, const unsigned char *atCharacterPtr) {
+  NSCParameterAssert((parseState != NULL) && (atCharacterPtr != NULL) && (atCharacterPtr >= parseState->stringBuffer.bytes.ptr) && (atCharacterPtr < JK_END_STRING_PTR(parseState)));
+  const unsigned char *endOfStringPtr = JK_END_STRING_PTR(parseState);
+
+  if(JK_EXPECT_F(atCharacterPtr >= endOfStringPtr)) { return(0UL); }
+
+  if(JK_EXPECT_F((*(atCharacterPtr + 0)) == '\n')) { return(1UL); }
+  if(JK_EXPECT_F((*(atCharacterPtr + 0)) == '\r')) { if((JK_EXPECT_T((atCharacterPtr + 1) < endOfStringPtr)) && ((*(atCharacterPtr + 1)) == '\n')) { return(2UL); } return(1UL); }
+  if(parseState->parseOptionFlags & JKParseOptionUnicodeNewlines) {
+    if((JK_EXPECT_F((*(atCharacterPtr + 0)) == 0xc2)) && (((atCharacterPtr + 1) < endOfStringPtr) && ((*(atCharacterPtr + 1)) == 0x85))) { return(2UL); }
+    if((JK_EXPECT_F((*(atCharacterPtr + 0)) == 0xe2)) && (((atCharacterPtr + 2) < endOfStringPtr) && ((*(atCharacterPtr + 1)) == 0x80) && (((*(atCharacterPtr + 2)) == 0xa8) || ((*(atCharacterPtr + 2)) == 0xa9)))) { return(3UL); }
+  }
+
+  return(0UL);
+}
+
+JK_STATIC_INLINE int jk_parse_skip_newline(JKParseState *parseState) {
+  size_t newlineAdvanceAtIndex = 0UL;
+  if(JK_EXPECT_F((newlineAdvanceAtIndex = jk_parse_is_newline(parseState, JK_AT_STRING_PTR(parseState))) > 0UL)) { parseState->lineNumber++; parseState->atIndex += (newlineAdvanceAtIndex - 1UL); parseState->lineStartIndex = parseState->atIndex + 1UL; return(1); }
+  return(0);
+}
+
+JK_STATIC_INLINE void jk_parse_skip_whitespace(JKParseState *parseState) {
+#ifndef __clang_analyzer__
+  NSCParameterAssert((parseState != NULL) && (JK_AT_STRING_PTR(parseState) <= JK_END_STRING_PTR(parseState)));
+  const unsigned char *atCharacterPtr   = NULL;
+  const unsigned char *endOfStringPtr   = JK_END_STRING_PTR(parseState);
+
+  for(atCharacterPtr = JK_AT_STRING_PTR(parseState); (JK_EXPECT_T((atCharacterPtr = JK_AT_STRING_PTR(parseState)) < endOfStringPtr)); parseState->atIndex++) {
+    if(((*(atCharacterPtr + 0)) == ' ') || ((*(atCharacterPtr + 0)) == '\t')) { continue; }
+    if(jk_parse_skip_newline(parseState)) { continue; }
+    if(parseState->parseOptionFlags & JKParseOptionComments) {
+      if((JK_EXPECT_F((*(atCharacterPtr + 0)) == '/')) && (JK_EXPECT_T((atCharacterPtr + 1) < endOfStringPtr))) {
+        if((*(atCharacterPtr + 1)) == '/') {
+          parseState->atIndex++;
+          for(atCharacterPtr = JK_AT_STRING_PTR(parseState); (JK_EXPECT_T((atCharacterPtr = JK_AT_STRING_PTR(parseState)) < endOfStringPtr)); parseState->atIndex++) { if(jk_parse_skip_newline(parseState)) { break; } }
+          continue;
+        }
+        if((*(atCharacterPtr + 1)) == '*') {
+          parseState->atIndex++;
+          for(atCharacterPtr = JK_AT_STRING_PTR(parseState); (JK_EXPECT_T((atCharacterPtr = JK_AT_STRING_PTR(parseState)) < endOfStringPtr)); parseState->atIndex++) {
+            if(jk_parse_skip_newline(parseState)) { continue; }
+            if(((*(atCharacterPtr + 0)) == '*') && (((atCharacterPtr + 1) < endOfStringPtr) && ((*(atCharacterPtr + 1)) == '/'))) { parseState->atIndex++; break; }
+          }
+          continue;
+        }
+      }
+    }
+    break;
+  }
+#endif
+}
+
+static int jk_parse_next_token(JKParseState *parseState) {
+  NSCParameterAssert((parseState != NULL) && (JK_AT_STRING_PTR(parseState) <= JK_END_STRING_PTR(parseState)));
+  const unsigned char *atCharacterPtr   = NULL;
+  const unsigned char *endOfStringPtr   = JK_END_STRING_PTR(parseState);
+  unsigned char        currentCharacter = 0U;
+  int                  stopParsing      = 0;
+
+  parseState->prev_atIndex        = parseState->atIndex;
+  parseState->prev_lineNumber     = parseState->lineNumber;
+  parseState->prev_lineStartIndex = parseState->lineStartIndex;
+
+  jk_parse_skip_whitespace(parseState);
+
+  if((JK_AT_STRING_PTR(parseState) == endOfStringPtr)) { stopParsing = 1; }
+
+  if((JK_EXPECT_T(stopParsing == 0)) && (JK_EXPECT_T((atCharacterPtr = JK_AT_STRING_PTR(parseState)) < endOfStringPtr))) {
+    currentCharacter = *atCharacterPtr;
+
+         if(JK_EXPECT_T(currentCharacter == '"')) { if(JK_EXPECT_T((stopParsing = jk_parse_string(parseState)) == 0)) { jk_set_parsed_token(parseState, parseState->token.tokenPtrRange.ptr, parseState->token.tokenPtrRange.length, JKTokenTypeString, 0UL); } }
+    else if(JK_EXPECT_T(currentCharacter == ':')) { jk_set_parsed_token(parseState, atCharacterPtr, 1UL, JKTokenTypeSeparator,   1UL); }
+    else if(JK_EXPECT_T(currentCharacter == ',')) { jk_set_parsed_token(parseState, atCharacterPtr, 1UL, JKTokenTypeComma,       1UL); }
+    else if((JK_EXPECT_T(currentCharacter >= '0') && JK_EXPECT_T(currentCharacter <= '9')) || JK_EXPECT_T(currentCharacter == '-')) { if(JK_EXPECT_T((stopParsing = jk_parse_number(parseState)) == 0)) { jk_set_parsed_token(parseState, parseState->token.tokenPtrRange.ptr, parseState->token.tokenPtrRange.length, JKTokenTypeNumber, 0UL); } }
+    else if(JK_EXPECT_T(currentCharacter == '{')) { jk_set_parsed_token(parseState, atCharacterPtr, 1UL, JKTokenTypeObjectBegin, 1UL); }
+    else if(JK_EXPECT_T(currentCharacter == '}')) { jk_set_parsed_token(parseState, atCharacterPtr, 1UL, JKTokenTypeObjectEnd,   1UL); }
+    else if(JK_EXPECT_T(currentCharacter == '[')) { jk_set_parsed_token(parseState, atCharacterPtr, 1UL, JKTokenTypeArrayBegin,  1UL); }
+    else if(JK_EXPECT_T(currentCharacter == ']')) { jk_set_parsed_token(parseState, atCharacterPtr, 1UL, JKTokenTypeArrayEnd,    1UL); }
+    
+    else if(JK_EXPECT_T(currentCharacter == 't')) { if(!((JK_EXPECT_T((atCharacterPtr + 4UL) < endOfStringPtr)) && (JK_EXPECT_T(atCharacterPtr[1] == 'r')) && (JK_EXPECT_T(atCharacterPtr[2] == 'u')) && (JK_EXPECT_T(atCharacterPtr[3] == 'e'))))                                            { stopParsing = 1; /* XXX Add error message */ } else { jk_set_parsed_token(parseState, atCharacterPtr, 4UL, JKTokenTypeTrue,  4UL); } }
+    else if(JK_EXPECT_T(currentCharacter == 'f')) { if(!((JK_EXPECT_T((atCharacterPtr + 5UL) < endOfStringPtr)) && (JK_EXPECT_T(atCharacterPtr[1] == 'a')) && (JK_EXPECT_T(atCharacterPtr[2] == 'l')) && (JK_EXPECT_T(atCharacterPtr[3] == 's')) && (JK_EXPECT_T(atCharacterPtr[4] == 'e')))) { stopParsing = 1; /* XXX Add error message */ } else { jk_set_parsed_token(parseState, atCharacterPtr, 5UL, JKTokenTypeFalse, 5UL); } }
+    else if(JK_EXPECT_T(currentCharacter == 'n')) { if(!((JK_EXPECT_T((atCharacterPtr + 4UL) < endOfStringPtr)) && (JK_EXPECT_T(atCharacterPtr[1] == 'u')) && (JK_EXPECT_T(atCharacterPtr[2] == 'l')) && (JK_EXPECT_T(atCharacterPtr[3] == 'l'))))                                            { stopParsing = 1; /* XXX Add error message */ } else { jk_set_parsed_token(parseState, atCharacterPtr, 4UL, JKTokenTypeNull,  4UL); } }
+    else { stopParsing = 1; /* XXX Add error message */ }    
+  }
+
+  if(JK_EXPECT_F(stopParsing)) { jk_error(parseState, @"Unexpected token, wanted '{', '}', '[', ']', ',', ':', 'true', 'false', 'null', '\"STRING\"', 'NUMBER'."); }
+  return(stopParsing);
+}
+
+static void jk_error_parse_accept_or3(JKParseState *parseState, int state, NSString *or1String, NSString *or2String, NSString *or3String) {
+  NSString *acceptStrings[16];
+  int acceptIdx = 0;
+  if(state & JKParseAcceptValue) { acceptStrings[acceptIdx++] = or1String; }
+  if(state & JKParseAcceptComma) { acceptStrings[acceptIdx++] = or2String; }
+  if(state & JKParseAcceptEnd)   { acceptStrings[acceptIdx++] = or3String; }
+       if(acceptIdx == 1) { jk_error(parseState, @"Expected %@, not '%*.*s'",           acceptStrings[0],                                     (int)parseState->token.tokenPtrRange.length, (int)parseState->token.tokenPtrRange.length, parseState->token.tokenPtrRange.ptr); }
+  else if(acceptIdx == 2) { jk_error(parseState, @"Expected %@ or %@, not '%*.*s'",     acceptStrings[0], acceptStrings[1],                   (int)parseState->token.tokenPtrRange.length, (int)parseState->token.tokenPtrRange.length, parseState->token.tokenPtrRange.ptr); }
+  else if(acceptIdx == 3) { jk_error(parseState, @"Expected %@, %@, or %@, not '%*.*s", acceptStrings[0], acceptStrings[1], acceptStrings[2], (int)parseState->token.tokenPtrRange.length, (int)parseState->token.tokenPtrRange.length, parseState->token.tokenPtrRange.ptr); }
+}
+
+static void *jk_parse_array(JKParseState *parseState) {
+  size_t  startingObjectIndex = parseState->objectStack.index;
+  int     arrayState          = JKParseAcceptValueOrEnd, stopParsing = 0;
+  void   *parsedArray         = NULL;
+
+  while(JK_EXPECT_T((JK_EXPECT_T(stopParsing == 0)) && (JK_EXPECT_T(parseState->atIndex < parseState->stringBuffer.bytes.length)))) {
+    if(JK_EXPECT_F(parseState->objectStack.index > (parseState->objectStack.count - 4UL))) { if(jk_objectStack_resize(&parseState->objectStack, parseState->objectStack.count + 128UL)) { jk_error(parseState, @"Internal error: [array] objectsIndex > %zu, resize failed? %@ line %#ld", (parseState->objectStack.count - 4UL), [NSString stringWithUTF8String:__FILE__], (long)__LINE__); break; } }
+
+    if(JK_EXPECT_T((stopParsing = jk_parse_next_token(parseState)) == 0)) {
+      void *object = NULL;
+#ifndef NS_BLOCK_ASSERTIONS
+      parseState->objectStack.objects[parseState->objectStack.index] = NULL;
+      parseState->objectStack.keys   [parseState->objectStack.index] = NULL;
+#endif
+      switch(parseState->token.type) {
+        case JKTokenTypeNumber:
+        case JKTokenTypeString:
+        case JKTokenTypeTrue:
+        case JKTokenTypeFalse:
+        case JKTokenTypeNull:
+        case JKTokenTypeArrayBegin:
+        case JKTokenTypeObjectBegin:
+          if(JK_EXPECT_F((arrayState & JKParseAcceptValue)          == 0))    { parseState->errorIsPrev = 1; jk_error(parseState, @"Unexpected value.");              stopParsing = 1; break; }
+          if(JK_EXPECT_F((object = jk_object_for_token(parseState)) == NULL)) {                              jk_error(parseState, @"Internal error: Object == NULL"); stopParsing = 1; break; } else { parseState->objectStack.objects[parseState->objectStack.index++] = object; arrayState = JKParseAcceptCommaOrEnd; }
+          break;
+        case JKTokenTypeArrayEnd: if(JK_EXPECT_T(arrayState & JKParseAcceptEnd)) { NSCParameterAssert(parseState->objectStack.index >= startingObjectIndex); parsedArray = (void *)_JKArrayCreate((id *)&parseState->objectStack.objects[startingObjectIndex], (parseState->objectStack.index - startingObjectIndex), parseState->mutableCollections); } else { parseState->errorIsPrev = 1; jk_error(parseState, @"Unexpected ']'."); } stopParsing = 1; break;
+        case JKTokenTypeComma:    if(JK_EXPECT_T(arrayState & JKParseAcceptComma)) { arrayState = JKParseAcceptValue; } else { parseState->errorIsPrev = 1; jk_error(parseState, @"Unexpected ','."); stopParsing = 1; } break;
+        default: parseState->errorIsPrev = 1; jk_error_parse_accept_or3(parseState, arrayState, @"a value", @"a comma", @"a ']'"); stopParsing = 1; break;
+      }
+    }
+  }
+
+  if(JK_EXPECT_F(parsedArray == NULL)) { size_t idx = 0UL; for(idx = startingObjectIndex; idx < parseState->objectStack.index; idx++) { if(parseState->objectStack.objects[idx] != NULL) { CFRelease(parseState->objectStack.objects[idx]); parseState->objectStack.objects[idx] = NULL; } } }
+#if !defined(NS_BLOCK_ASSERTIONS)
+  else { size_t idx = 0UL; for(idx = startingObjectIndex; idx < parseState->objectStack.index; idx++) { parseState->objectStack.objects[idx] = NULL; parseState->objectStack.keys[idx] = NULL; } }
+#endif
+  
+  parseState->objectStack.index = startingObjectIndex;
+  return(parsedArray);
+}
+
+static void *jk_create_dictionary(JKParseState *parseState, size_t startingObjectIndex) {
+  void *parsedDictionary = NULL;
+
+  parseState->objectStack.index--;
+
+  parsedDictionary = _JKDictionaryCreate((id *)&parseState->objectStack.keys[startingObjectIndex], (NSUInteger *)&parseState->objectStack.cfHashes[startingObjectIndex], (id *)&parseState->objectStack.objects[startingObjectIndex], (parseState->objectStack.index - startingObjectIndex), parseState->mutableCollections);
+
+  return(parsedDictionary);
+}
+
+static void *jk_parse_dictionary(JKParseState *parseState) {
+  size_t  startingObjectIndex = parseState->objectStack.index;
+  int     dictState           = JKParseAcceptValueOrEnd, stopParsing = 0;
+  void   *parsedDictionary    = NULL;
+
+  while(JK_EXPECT_T((JK_EXPECT_T(stopParsing == 0)) && (JK_EXPECT_T(parseState->atIndex < parseState->stringBuffer.bytes.length)))) {
+    if(JK_EXPECT_F(parseState->objectStack.index > (parseState->objectStack.count - 4UL))) { if(jk_objectStack_resize(&parseState->objectStack, parseState->objectStack.count + 128UL)) { jk_error(parseState, @"Internal error: [dictionary] objectsIndex > %zu, resize failed? %@ line #%ld", (parseState->objectStack.count - 4UL), [NSString stringWithUTF8String:__FILE__], (long)__LINE__); break; } }
+
+    size_t objectStackIndex = parseState->objectStack.index++;
+    parseState->objectStack.keys[objectStackIndex]    = NULL;
+    parseState->objectStack.objects[objectStackIndex] = NULL;
+    void *key = NULL, *object = NULL;
+
+    if(JK_EXPECT_T((JK_EXPECT_T(stopParsing == 0)) && (JK_EXPECT_T((stopParsing = jk_parse_next_token(parseState)) == 0)))) {
+      switch(parseState->token.type) {
+        case JKTokenTypeString:
+          if(JK_EXPECT_F((dictState & JKParseAcceptValue)        == 0))    { parseState->errorIsPrev = 1; jk_error(parseState, @"Unexpected string.");           stopParsing = 1; break; }
+          if(JK_EXPECT_F((key = jk_object_for_token(parseState)) == NULL)) {                              jk_error(parseState, @"Internal error: Key == NULL."); stopParsing = 1; break; }
+          else {
+            parseState->objectStack.keys[objectStackIndex] = key;
+            if(JK_EXPECT_T(parseState->token.value.cacheItem != NULL)) { if(JK_EXPECT_F(parseState->token.value.cacheItem->cfHash == 0UL)) { parseState->token.value.cacheItem->cfHash = CFHash(key); } parseState->objectStack.cfHashes[objectStackIndex] = parseState->token.value.cacheItem->cfHash; }
+            else { parseState->objectStack.cfHashes[objectStackIndex] = CFHash(key); }
+          }
+          break;
+
+        case JKTokenTypeObjectEnd: if((JK_EXPECT_T(dictState & JKParseAcceptEnd)))   { NSCParameterAssert(parseState->objectStack.index >= startingObjectIndex); parsedDictionary = jk_create_dictionary(parseState, startingObjectIndex); } else { parseState->errorIsPrev = 1; jk_error(parseState, @"Unexpected '}'."); } stopParsing = 1; break;
+        case JKTokenTypeComma:     if((JK_EXPECT_T(dictState & JKParseAcceptComma))) { dictState = JKParseAcceptValue; parseState->objectStack.index--; continue; } else { parseState->errorIsPrev = 1; jk_error(parseState, @"Unexpected ','."); stopParsing = 1; } break;
+
+        default: parseState->errorIsPrev = 1; jk_error_parse_accept_or3(parseState, dictState, @"a \"STRING\"", @"a comma", @"a '}'"); stopParsing = 1; break;
+      }
+    }
+
+    if(JK_EXPECT_T(stopParsing == 0)) {
+      if(JK_EXPECT_T((stopParsing = jk_parse_next_token(parseState)) == 0)) { if(JK_EXPECT_F(parseState->token.type != JKTokenTypeSeparator)) { parseState->errorIsPrev = 1; jk_error(parseState, @"Expected ':'."); stopParsing = 1; } }
+    }
+
+    if((JK_EXPECT_T(stopParsing == 0)) && (JK_EXPECT_T((stopParsing = jk_parse_next_token(parseState)) == 0))) {
+      switch(parseState->token.type) {
+        case JKTokenTypeNumber:
+        case JKTokenTypeString:
+        case JKTokenTypeTrue:
+        case JKTokenTypeFalse:
+        case JKTokenTypeNull:
+        case JKTokenTypeArrayBegin:
+        case JKTokenTypeObjectBegin:
+          if(JK_EXPECT_F((dictState & JKParseAcceptValue)           == 0))    { parseState->errorIsPrev = 1; jk_error(parseState, @"Unexpected value.");               stopParsing = 1; break; }
+          if(JK_EXPECT_F((object = jk_object_for_token(parseState)) == NULL)) {                              jk_error(parseState, @"Internal error: Object == NULL."); stopParsing = 1; break; } else { parseState->objectStack.objects[objectStackIndex] = object; dictState = JKParseAcceptCommaOrEnd; }
+          break;
+        default: parseState->errorIsPrev = 1; jk_error_parse_accept_or3(parseState, dictState, @"a value", @"a comma", @"a '}'"); stopParsing = 1; break;
+      }
+    }
+  }
+
+  if(JK_EXPECT_F(parsedDictionary == NULL)) { size_t idx = 0UL; for(idx = startingObjectIndex; idx < parseState->objectStack.index; idx++) { if(parseState->objectStack.keys[idx] != NULL) { CFRelease(parseState->objectStack.keys[idx]); parseState->objectStack.keys[idx] = NULL; } if(parseState->objectStack.objects[idx] != NULL) { CFRelease(parseState->objectStack.objects[idx]); parseState->objectStack.objects[idx] = NULL; } } }
+#if !defined(NS_BLOCK_ASSERTIONS)
+  else { size_t idx = 0UL; for(idx = startingObjectIndex; idx < parseState->objectStack.index; idx++) { parseState->objectStack.objects[idx] = NULL; parseState->objectStack.keys[idx] = NULL; } }
+#endif
+
+  parseState->objectStack.index = startingObjectIndex;
+  return(parsedDictionary);
+}
+
+static id json_parse_it(JKParseState *parseState) {
+  id  parsedObject = NULL;
+  int stopParsing  = 0;
+
+  while((JK_EXPECT_T(stopParsing == 0)) && (JK_EXPECT_T(parseState->atIndex < parseState->stringBuffer.bytes.length))) {
+    if((JK_EXPECT_T(stopParsing == 0)) && (JK_EXPECT_T((stopParsing = jk_parse_next_token(parseState)) == 0))) {
+      switch(parseState->token.type) {
+        case JKTokenTypeArrayBegin:
+        case JKTokenTypeObjectBegin: parsedObject = [(id)jk_object_for_token(parseState) autorelease]; stopParsing = 1; break;
+        default:                     jk_error(parseState, @"Expected either '[' or '{'.");             stopParsing = 1; break;
+      }
+    }
+  }
+
+  NSCParameterAssert((parseState->objectStack.index == 0) && (JK_AT_STRING_PTR(parseState) <= JK_END_STRING_PTR(parseState)));
+
+  if((parsedObject == NULL) && (JK_AT_STRING_PTR(parseState) == JK_END_STRING_PTR(parseState))) { jk_error(parseState, @"Reached the end of the buffer."); }
+  if(parsedObject == NULL) { jk_error(parseState, @"Unable to parse JSON."); }
+
+  if((parsedObject != NULL) && (JK_AT_STRING_PTR(parseState) < JK_END_STRING_PTR(parseState))) {
+    jk_parse_skip_whitespace(parseState);
+    if((parsedObject != NULL) && ((parseState->parseOptionFlags & JKParseOptionPermitTextAfterValidJSON) == 0) && (JK_AT_STRING_PTR(parseState) < JK_END_STRING_PTR(parseState))) {
+      jk_error(parseState, @"A valid JSON object was parsed but there were additional non-white-space characters remaining.");
+      parsedObject = NULL;
+    }
+  }
+
+  return(parsedObject);
+}
+
+////////////
+#pragma mark -
+#pragma mark Object cache
+
+// This uses a Galois Linear Feedback Shift Register (LFSR) PRNG to pick which item in the cache to age. It has a period of (2^32)-1.
+// NOTE: A LFSR *MUST* be initialized to a non-zero value and must always have a non-zero value.
+JK_STATIC_INLINE void jk_cache_age(JKParseState *parseState) {
+  NSCParameterAssert((parseState != NULL) && (parseState->cache.prng_lfsr != 0U));
+  parseState->cache.prng_lfsr = (parseState->cache.prng_lfsr >> 1) ^ ((0U - (parseState->cache.prng_lfsr & 1U)) & 0x80200003U);
+  parseState->cache.age[parseState->cache.prng_lfsr & (parseState->cache.count - 1UL)] >>= 1;
+}
+
+// The object cache is nothing more than a hash table with open addressing collision resolution that is bounded by JK_CACHE_PROBES attempts.
+//
+// The hash table is a linear C array of JKTokenCacheItem.  The terms "item" and "bucket" are synonymous with the index in to the cache array, i.e. cache.items[bucket].
+//
+// Items in the cache have an age associated with them.  The age is the number of rightmost 1 bits, i.e. 0000 = 0, 0001 = 1, 0011 = 2, 0111 = 3, 1111 = 4.
+// This allows us to use left and right shifts to add or subtract from an items age.  Add = (age << 1) | 1.  Subtract = age >> 0.  Subtract is synonymous with "age" (i.e., age an item).
+// The reason for this is it allows us to perform saturated adds and subtractions and is branchless.
+// The primitive C type MUST be unsigned.  It is currently a "char", which allows (at a minimum and in practice) 8 bits.
+//
+// A "useable bucket" is a bucket that is not in use (never populated), or has an age == 0.
+//
+// When an item is found in the cache, it's age is incremented.
+// If a useable bucket hasn't been found, the current item (bucket) is aged along with two random items.
+//
+// If a value is not found in the cache, and no useable bucket has been found, that value is not added to the cache.
+
+static void *jk_cachedObjects(JKParseState *parseState) {
+  unsigned long  bucket     = parseState->token.value.hash & (parseState->cache.count - 1UL), setBucket = 0UL, useableBucket = 0UL, x = 0UL;
+  void          *parsedAtom = NULL;
+    
+  if(JK_EXPECT_F(parseState->token.value.ptrRange.length == 0UL) && JK_EXPECT_T(parseState->token.value.type == JKValueTypeString)) { return(@""); }
+  
+  for(x = 0UL; x < JK_CACHE_PROBES; x++) {
+    if(JK_EXPECT_F(parseState->cache.items[bucket].object == NULL)) { setBucket = 1UL; useableBucket = bucket; break; }
+    
+    if((JK_EXPECT_T(parseState->cache.items[bucket].hash == parseState->token.value.hash)) && (JK_EXPECT_T(parseState->cache.items[bucket].size == parseState->token.value.ptrRange.length)) && (JK_EXPECT_T(parseState->cache.items[bucket].type == parseState->token.value.type)) && (JK_EXPECT_T(parseState->cache.items[bucket].bytes != NULL)) && (JK_EXPECT_T(strncmp((const char *)parseState->cache.items[bucket].bytes, (const char *)parseState->token.value.ptrRange.ptr, parseState->token.value.ptrRange.length) == 0U))) {
+      parseState->cache.age[bucket]     = (parseState->cache.age[bucket] << 1) | 1U;
+      parseState->token.value.cacheItem = &parseState->cache.items[bucket];
+      NSCParameterAssert(parseState->cache.items[bucket].object != NULL);
+      return((void *)CFRetain(parseState->cache.items[bucket].object));
+    } else {
+      if(JK_EXPECT_F(setBucket == 0UL) && JK_EXPECT_F(parseState->cache.age[bucket] == 0U)) { setBucket = 1UL; useableBucket = bucket; }
+      if(JK_EXPECT_F(setBucket == 0UL))                                                     { parseState->cache.age[bucket] >>= 1; jk_cache_age(parseState); jk_cache_age(parseState); }
+      // This is the open addressing function.  The values length and type are used as a form of "double hashing" to distribute values with the same effective value hash across different object cache buckets.
+      // The values type is a prime number that is relatively coprime to the other primes in the set of value types and the number of hash table buckets.
+      bucket = (parseState->token.value.hash + (parseState->token.value.ptrRange.length * (x + 1UL)) + (parseState->token.value.type * (x + 1UL)) + (3UL * (x + 1UL))) & (parseState->cache.count - 1UL);
+    }
+  }
+  
+  switch(parseState->token.value.type) {
+    case JKValueTypeString:           parsedAtom = (void *)CFStringCreateWithBytes(NULL, parseState->token.value.ptrRange.ptr, parseState->token.value.ptrRange.length, kCFStringEncodingUTF8, 0); break;
+    case JKValueTypeLongLong:         parsedAtom = (void *)CFNumberCreate(NULL, kCFNumberLongLongType, &parseState->token.value.number.longLongValue);                                             break;
+    case JKValueTypeUnsignedLongLong:
+      if(parseState->token.value.number.unsignedLongLongValue <= LLONG_MAX) { parsedAtom = (void *)CFNumberCreate(NULL, kCFNumberLongLongType, &parseState->token.value.number.unsignedLongLongValue); }
+      else { parsedAtom = (void *)parseState->objCImpCache.NSNumberInitWithUnsignedLongLong(parseState->objCImpCache.NSNumberAlloc(parseState->objCImpCache.NSNumberClass, @selector(alloc)), @selector(initWithUnsignedLongLong:), parseState->token.value.number.unsignedLongLongValue); }
+      break;
+    case JKValueTypeDouble:           parsedAtom = (void *)CFNumberCreate(NULL, kCFNumberDoubleType,   &parseState->token.value.number.doubleValue);                                               break;
+    default: jk_error(parseState, @"Internal error: Unknown token value type. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); break;
+  }
+  
+  if(JK_EXPECT_T(setBucket) && (JK_EXPECT_T(parsedAtom != NULL))) {
+    bucket = useableBucket;
+    if(JK_EXPECT_T((parseState->cache.items[bucket].object != NULL))) { CFRelease(parseState->cache.items[bucket].object); parseState->cache.items[bucket].object = NULL; }
+    
+    if(JK_EXPECT_T((parseState->cache.items[bucket].bytes = (unsigned char *)reallocf(parseState->cache.items[bucket].bytes, parseState->token.value.ptrRange.length)) != NULL)) {
+      memcpy(parseState->cache.items[bucket].bytes, parseState->token.value.ptrRange.ptr, parseState->token.value.ptrRange.length);
+      parseState->cache.items[bucket].object = (void *)CFRetain(parsedAtom);
+      parseState->cache.items[bucket].hash   = parseState->token.value.hash;
+      parseState->cache.items[bucket].cfHash = 0UL;
+      parseState->cache.items[bucket].size   = parseState->token.value.ptrRange.length;
+      parseState->cache.items[bucket].type   = parseState->token.value.type;
+      parseState->token.value.cacheItem      = &parseState->cache.items[bucket];
+      parseState->cache.age[bucket]          = JK_INIT_CACHE_AGE;
+    } else { // The realloc failed, so clear the appropriate fields.
+      parseState->cache.items[bucket].hash   = 0UL;
+      parseState->cache.items[bucket].cfHash = 0UL;
+      parseState->cache.items[bucket].size   = 0UL;
+      parseState->cache.items[bucket].type   = 0UL;
+    }
+  }
+  
+  return(parsedAtom);
+}
+
+
+static void *jk_object_for_token(JKParseState *parseState) {
+  void *parsedAtom = NULL;
+  
+  parseState->token.value.cacheItem = NULL;
+  switch(parseState->token.type) {
+    case JKTokenTypeString:      parsedAtom = jk_cachedObjects(parseState);    break;
+    case JKTokenTypeNumber:      parsedAtom = jk_cachedObjects(parseState);    break;
+    case JKTokenTypeObjectBegin: parsedAtom = jk_parse_dictionary(parseState); break;
+    case JKTokenTypeArrayBegin:  parsedAtom = jk_parse_array(parseState);      break;
+    case JKTokenTypeTrue:        parsedAtom = (void *)kCFBooleanTrue;          break;
+    case JKTokenTypeFalse:       parsedAtom = (void *)kCFBooleanFalse;         break;
+    case JKTokenTypeNull:        parsedAtom = (void *)kCFNull;                 break;
+    default: jk_error(parseState, @"Internal error: Unknown token type. %@ line #%ld", [NSString stringWithUTF8String:__FILE__], (long)__LINE__); break;
+  }
+  
+  return(parsedAtom);
+}
+
+#pragma mark -
+@implementation JSONDecoder
+
++ (id)decoder
+{
+  return([self decoderWithParseOptions:JKParseOptionStrict]);
+}
+
++ (id)decoderWithParseOptions:(JKParseOptionFlags)parseOptionFlags
+{
+  return([[[self alloc] initWithParseOptions:parseOptionFlags] autorelease]);
+}
+
+- (id)init
+{
+  return([self initWithParseOptions:JKParseOptionStrict]);
+}
+
+- (id)initWithParseOptions:(JKParseOptionFlags)parseOptionFlags
+{
+  if((self = [super init]) == NULL) { return(NULL); }
+
+  if(parseOptionFlags & ~JKParseOptionValidFlags) { [self autorelease]; [NSException raise:NSInvalidArgumentException format:@"Invalid parse options."]; }
+
+  if((parseState = (JKParseState *)calloc(1UL, sizeof(JKParseState))) == NULL) { goto errorExit; }
+
+  parseState->parseOptionFlags = parseOptionFlags;
+  
+  parseState->token.tokenBuffer.roundSizeUpToMultipleOf = 4096UL;
+  parseState->objectStack.roundSizeUpToMultipleOf       = 2048UL;
+
+  parseState->objCImpCache.NSNumberClass                    = _jk_NSNumberClass;
+  parseState->objCImpCache.NSNumberAlloc                    = _jk_NSNumberAllocImp;
+  parseState->objCImpCache.NSNumberInitWithUnsignedLongLong = _jk_NSNumberInitWithUnsignedLongLongImp;
+  
+  parseState->cache.prng_lfsr = 1U;
+  parseState->cache.count     = JK_CACHE_SLOTS;
+  if((parseState->cache.items = (JKTokenCacheItem *)calloc(1UL, sizeof(JKTokenCacheItem) * parseState->cache.count)) == NULL) { goto errorExit; }
+
+  return(self);
+
+ errorExit:
+  if(self) { [self autorelease]; self = NULL; }
+  return(NULL);
+}
+
+// This is here primarily to support the NSString and NSData convenience functions so the autoreleased JSONDecoder can release most of its resources before the pool pops.
+static void _JSONDecoderCleanup(JSONDecoder *decoder) {
+  if((decoder != NULL) && (decoder->parseState != NULL)) {
+    jk_managedBuffer_release(&decoder->parseState->token.tokenBuffer);
+    jk_objectStack_release(&decoder->parseState->objectStack);
+    
+    [decoder clearCache];
+    if(decoder->parseState->cache.items != NULL) { free(decoder->parseState->cache.items); decoder->parseState->cache.items = NULL; }
+    
+    free(decoder->parseState); decoder->parseState = NULL;
+  }
+}
+
+- (void)dealloc
+{
+  _JSONDecoderCleanup(self);
+  [super dealloc];
+}
+
+- (void)clearCache
+{
+  if(JK_EXPECT_T(parseState != NULL)) {
+    if(JK_EXPECT_T(parseState->cache.items != NULL)) {
+      size_t idx = 0UL;
+      for(idx = 0UL; idx < parseState->cache.count; idx++) {
+        if(JK_EXPECT_T(parseState->cache.items[idx].object != NULL)) { CFRelease(parseState->cache.items[idx].object); parseState->cache.items[idx].object = NULL; }
+        if(JK_EXPECT_T(parseState->cache.items[idx].bytes  != NULL)) { free(parseState->cache.items[idx].bytes);       parseState->cache.items[idx].bytes  = NULL; }
+        memset(&parseState->cache.items[idx], 0, sizeof(JKTokenCacheItem));
+        parseState->cache.age[idx] = 0U;
+      }
+    }
+  }
+}
+
+// This needs to be completely rewritten.
+static id _JKParseUTF8String(JKParseState *parseState, BOOL mutableCollections, const unsigned char *string, size_t length, NSError **error) {
+  NSCParameterAssert((parseState != NULL) && (string != NULL) && (parseState->cache.prng_lfsr != 0U));
+  parseState->stringBuffer.bytes.ptr    = string;
+  parseState->stringBuffer.bytes.length = length;
+  parseState->atIndex                   = 0UL;
+  parseState->lineNumber                = 1UL;
+  parseState->lineStartIndex            = 0UL;
+  parseState->prev_atIndex              = 0UL;
+  parseState->prev_lineNumber           = 1UL;
+  parseState->prev_lineStartIndex       = 0UL;
+  parseState->error                     = NULL;
+  parseState->errorIsPrev               = 0;
+  parseState->mutableCollections        = (mutableCollections == NO) ? NO : YES;
+  
+  unsigned char stackTokenBuffer[JK_TOKENBUFFER_SIZE] JK_ALIGNED(64);
+  jk_managedBuffer_setToStackBuffer(&parseState->token.tokenBuffer, stackTokenBuffer, sizeof(stackTokenBuffer));
+  
+  void       *stackObjects [JK_STACK_OBJS] JK_ALIGNED(64);
+  void       *stackKeys    [JK_STACK_OBJS] JK_ALIGNED(64);
+  CFHashCode  stackCFHashes[JK_STACK_OBJS] JK_ALIGNED(64);
+  jk_objectStack_setToStackBuffer(&parseState->objectStack, stackObjects, stackKeys, stackCFHashes, JK_STACK_OBJS);
+  
+  id parsedJSON = json_parse_it(parseState);
+  
+  if((error != NULL) && (parseState->error != NULL)) { *error = parseState->error; }
+  
+  jk_managedBuffer_release(&parseState->token.tokenBuffer);
+  jk_objectStack_release(&parseState->objectStack);
+  
+  parseState->stringBuffer.bytes.ptr    = NULL;
+  parseState->stringBuffer.bytes.length = 0UL;
+  parseState->atIndex                   = 0UL;
+  parseState->lineNumber                = 1UL;
+  parseState->lineStartIndex            = 0UL;
+  parseState->prev_atIndex              = 0UL;
+  parseState->prev_lineNumber           = 1UL;
+  parseState->prev_lineStartIndex       = 0UL;
+  parseState->error                     = NULL;
+  parseState->errorIsPrev               = 0;
+  parseState->mutableCollections        = NO;
+  
+  return(parsedJSON);
+}
+
+////////////
+#pragma mark Deprecated as of v1.4
+////////////
+
+// Deprecated in JSONKit v1.4.  Use objectWithUTF8String:length: instead.
+- (id)parseUTF8String:(const unsigned char *)string length:(size_t)length
+{
+  return([self objectWithUTF8String:string length:length error:NULL]);
+}
+
+// Deprecated in JSONKit v1.4.  Use objectWithUTF8String:length:error: instead.
+- (id)parseUTF8String:(const unsigned char *)string length:(size_t)length error:(NSError **)error
+{
+  return([self objectWithUTF8String:string length:length error:error]);
+}
+
+// Deprecated in JSONKit v1.4.  Use objectWithData: instead.
+- (id)parseJSONData:(NSData *)jsonData
+{
+  return([self objectWithData:jsonData error:NULL]);
+}
+
+// Deprecated in JSONKit v1.4.  Use objectWithData:error: instead.
+- (id)parseJSONData:(NSData *)jsonData error:(NSError **)error
+{
+  return([self objectWithData:jsonData error:error]);
+}
+
+////////////
+#pragma mark Methods that return immutable collection objects
+////////////
+
+- (id)objectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length
+{
+  return([self objectWithUTF8String:string length:length error:NULL]);
+}
+
+- (id)objectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length error:(NSError **)error
+{
+  if(parseState == NULL) { [NSException raise:NSInternalInconsistencyException format:@"parseState is NULL."];          }
+  if(string     == NULL) { [NSException raise:NSInvalidArgumentException       format:@"The string argument is NULL."]; }
+  
+  return(_JKParseUTF8String(parseState, NO, string, (size_t)length, error));
+}
+
+- (id)objectWithData:(NSData *)jsonData
+{
+  return([self objectWithData:jsonData error:NULL]);
+}
+
+- (id)objectWithData:(NSData *)jsonData error:(NSError **)error
+{
+  if(jsonData == NULL) { [NSException raise:NSInvalidArgumentException format:@"The jsonData argument is NULL."]; }
+  return([self objectWithUTF8String:(const unsigned char *)[jsonData bytes] length:[jsonData length] error:error]);
+}
+
+////////////
+#pragma mark Methods that return mutable collection objects
+////////////
+
+- (id)mutableObjectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length
+{
+  return([self mutableObjectWithUTF8String:string length:length error:NULL]);
+}
+
+- (id)mutableObjectWithUTF8String:(const unsigned char *)string length:(NSUInteger)length error:(NSError **)error
+{
+  if(parseState == NULL) { [NSException raise:NSInternalInconsistencyException format:@"parseState is NULL."];          }
+  if(string     == NULL) { [NSException raise:NSInvalidArgumentException       format:@"The string argument is NULL."]; }
+  
+  return(_JKParseUTF8String(parseState, YES, string, (size_t)length, error));
+}
+
+- (id)mutableObjectWithData:(NSData *)jsonData
+{
+  return([self mutableObjectWithData:jsonData error:NULL]);
+}
+
+- (id)mutableObjectWithData:(NSData *)jsonData error:(NSError **)error
+{
+  if(jsonData == NULL) { [NSException raise:NSInvalidArgumentException format:@"The jsonData argument is NULL."]; }
+  return([self mutableObjectWithUTF8String:(const unsigned char *)[jsonData bytes] length:[jsonData length] error:error]);
+}
+
+@end
+
+/*
+ The NSString and NSData convenience methods need a little bit of explanation.
+ 
+ Prior to JSONKit v1.4, the NSString -objectFromJSONStringWithParseOptions:error: method looked like
+ 
+ const unsigned char *utf8String = (const unsigned char *)[self UTF8String];
+ if(utf8String == NULL) { return(NULL); }
+ size_t               utf8Length = strlen((const char *)utf8String); 
+ return([[JSONDecoder decoderWithParseOptions:parseOptionFlags] parseUTF8String:utf8String length:utf8Length error:error]);
+ 
+ This changed with v1.4 to a more complicated method.  The reason for this is to keep the amount of memory that is
+ allocated, but not yet freed because it is dependent on the autorelease pool to pop before it can be reclaimed.
+ 
+ In the simpler v1.3 code, this included all the bytes used to store the -UTF8String along with the JSONDecoder and all its overhead.
+ 
+ Now we use an autoreleased CFMutableData that is sized to the UTF8 length of the NSString in question and is used to hold the UTF8
+ conversion of said string.
+ 
+ Once parsed, the CFMutableData has its length set to 0.  This should, hopefully, allow the CFMutableData to realloc and/or free
+ the buffer.
+ 
+ Another change made was a slight modification to JSONDecoder so that most of the cleanup work that was done in -dealloc was moved
+ to a private, internal function.  These convenience routines keep the pointer to the autoreleased JSONDecoder and calls
+ _JSONDecoderCleanup() to early release the decoders resources since we already know that particular decoder is not going to be used
+ again.  
+ 
+ If everything goes smoothly, this will most likely result in perhaps a few hundred bytes that are allocated but waiting for the
+ autorelease pool to pop.  This is compared to the thousands and easily hundreds of thousands of bytes that would have been in
+ autorelease limbo.  It's more complicated for us, but a win for the user.
+ 
+ Autorelease objects are used in case things don't go smoothly.  By having them autoreleased, we effectively guarantee that our
+ requirement to -release the object is always met, not matter what goes wrong.  The downside is having a an object or two in
+ autorelease limbo, but we've done our best to minimize that impact, so it all balances out.
+ */
+
+@implementation NSString (JSONKitDeserializing)
+
+static id _NSStringObjectFromJSONString(NSString *jsonString, JKParseOptionFlags parseOptionFlags, NSError **error, BOOL mutableCollection) {
+  id                returnObject = NULL;
+  CFMutableDataRef  mutableData  = NULL;
+  JSONDecoder      *decoder      = NULL;
+  
+  CFIndex    stringLength     = CFStringGetLength((CFStringRef)jsonString);
+  NSUInteger stringUTF8Length = [jsonString lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+  
+  if((mutableData = (CFMutableDataRef)[(id)CFDataCreateMutable(NULL, (NSUInteger)stringUTF8Length) autorelease]) != NULL) {
+    UInt8   *utf8String = CFDataGetMutableBytePtr(mutableData);
+    CFIndex  usedBytes  = 0L, convertedCount = 0L;
+    
+    convertedCount = CFStringGetBytes((CFStringRef)jsonString, CFRangeMake(0L, stringLength), kCFStringEncodingUTF8, '?', NO, utf8String, (NSUInteger)stringUTF8Length, &usedBytes);
+    if(JK_EXPECT_F(convertedCount != stringLength) || JK_EXPECT_F(usedBytes < 0L)) { if(error != NULL) { *error = [NSError errorWithDomain:@"JKErrorDomain" code:-1L userInfo:[NSDictionary dictionaryWithObject:@"An error occurred converting the contents of a NSString to UTF8." forKey:NSLocalizedDescriptionKey]]; } goto exitNow; }
+    
+    if(mutableCollection == NO) { returnObject = [(decoder = [JSONDecoder decoderWithParseOptions:parseOptionFlags])        objectWithUTF8String:(const unsigned char *)utf8String length:(size_t)usedBytes error:error]; }
+    else                        { returnObject = [(decoder = [JSONDecoder decoderWithParseOptions:parseOptionFlags]) mutableObjectWithUTF8String:(const unsigned char *)utf8String length:(size_t)usedBytes error:error]; }
+  }
+  
+exitNow:
+  if(mutableData != NULL) { CFDataSetLength(mutableData, 0L); }
+  if(decoder     != NULL) { _JSONDecoderCleanup(decoder);     }
+  return(returnObject);
+}
+
+- (id)objectFromJSONString
+{
+  return([self objectFromJSONStringWithParseOptions:JKParseOptionStrict error:NULL]);
+}
+
+- (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags
+{
+  return([self objectFromJSONStringWithParseOptions:parseOptionFlags error:NULL]);
+}
+
+- (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error
+{
+  return(_NSStringObjectFromJSONString(self, parseOptionFlags, error, NO));
+}
+
+
+- (id)mutableObjectFromJSONString
+{
+  return([self mutableObjectFromJSONStringWithParseOptions:JKParseOptionStrict error:NULL]);
+}
+
+- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags
+{
+  return([self mutableObjectFromJSONStringWithParseOptions:parseOptionFlags error:NULL]);
+}
+
+- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error
+{
+  return(_NSStringObjectFromJSONString(self, parseOptionFlags, error, YES));
+}
+
+@end
+
+@implementation NSData (JSONKitDeserializing)
+
+- (id)objectFromJSONData
+{
+  return([self objectFromJSONDataWithParseOptions:JKParseOptionStrict error:NULL]);
+}
+
+- (id)objectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags
+{
+  return([self objectFromJSONDataWithParseOptions:parseOptionFlags error:NULL]);
+}
+
+- (id)objectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error
+{
+  JSONDecoder *decoder = NULL;
+  id returnObject = [(decoder = [JSONDecoder decoderWithParseOptions:parseOptionFlags]) objectWithData:self error:error];
+  if(decoder != NULL) { _JSONDecoderCleanup(decoder); }
+  return(returnObject);
+}
+
+- (id)mutableObjectFromJSONData
+{
+  return([self mutableObjectFromJSONDataWithParseOptions:JKParseOptionStrict error:NULL]);
+}
+
+- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags
+{
+  return([self mutableObjectFromJSONDataWithParseOptions:parseOptionFlags error:NULL]);
+}
+
+- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error
+{
+  JSONDecoder *decoder = NULL;
+  id returnObject = [(decoder = [JSONDecoder decoderWithParseOptions:parseOptionFlags]) mutableObjectWithData:self error:error];
+  if(decoder != NULL) { _JSONDecoderCleanup(decoder); }
+  return(returnObject);
+}
+
+
+@end
+
+////////////
+#pragma mark -
+#pragma mark Encoding / deserializing functions
+
+static void jk_encode_error(JKEncodeState *encodeState, NSString *format, ...) {
+  NSCParameterAssert((encodeState != NULL) && (format != NULL));
+
+  va_list varArgsList;
+  va_start(varArgsList, format);
+  NSString *formatString = [[[NSString alloc] initWithFormat:format arguments:varArgsList] autorelease];
+  va_end(varArgsList);
+
+  if(encodeState->error == NULL) {
+    encodeState->error = [NSError errorWithDomain:@"JKErrorDomain" code:-1L userInfo:
+                                   [NSDictionary dictionaryWithObjectsAndKeys:
+                                                                              formatString, NSLocalizedDescriptionKey,
+                                                                              NULL]];
+  }
+}
+
+JK_STATIC_INLINE void jk_encode_updateCache(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object) {
+  NSCParameterAssert(encodeState != NULL);
+  if(JK_EXPECT_T(cacheSlot != NULL)) {
+    NSCParameterAssert((object != NULL) && (startingAtIndex <= encodeState->atIndex));
+    cacheSlot->object = object;
+    cacheSlot->offset = startingAtIndex;
+    cacheSlot->length = (size_t)(encodeState->atIndex - startingAtIndex);  
+  }
+}
+
+static int jk_encode_printf(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object, const char *format, ...) {
+  va_list varArgsList, varArgsListCopy;
+  va_start(varArgsList, format);
+  va_copy(varArgsListCopy, varArgsList);
+
+  NSCParameterAssert((encodeState != NULL) && (encodeState->atIndex < encodeState->stringBuffer.bytes.length) && (startingAtIndex <= encodeState->atIndex) && (format != NULL));
+
+  ssize_t  formattedStringLength = 0L;
+  int      returnValue           = 0;
+
+  if(JK_EXPECT_T((formattedStringLength = vsnprintf((char *)&encodeState->stringBuffer.bytes.ptr[encodeState->atIndex], (encodeState->stringBuffer.bytes.length - encodeState->atIndex), format, varArgsList)) >= (ssize_t)(encodeState->stringBuffer.bytes.length - encodeState->atIndex))) {
+    NSCParameterAssert(((encodeState->atIndex + (formattedStringLength * 2UL) + 256UL) > encodeState->stringBuffer.bytes.length));
+    if(JK_EXPECT_F(((encodeState->atIndex + (formattedStringLength * 2UL) + 256UL) > encodeState->stringBuffer.bytes.length)) && JK_EXPECT_F((jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + (formattedStringLength * 2UL)+ 4096UL) == NULL))) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); returnValue = 1; goto exitNow; }
+    if(JK_EXPECT_F((formattedStringLength = vsnprintf((char *)&encodeState->stringBuffer.bytes.ptr[encodeState->atIndex], (encodeState->stringBuffer.bytes.length - encodeState->atIndex), format, varArgsListCopy)) >= (ssize_t)(encodeState->stringBuffer.bytes.length - encodeState->atIndex))) { jk_encode_error(encodeState, @"vsnprintf failed unexpectedly."); returnValue = 1; goto exitNow; }
+  }
+  
+exitNow:
+  va_end(varArgsList);
+  va_end(varArgsListCopy);
+  if(JK_EXPECT_T(returnValue == 0)) { encodeState->atIndex += formattedStringLength; jk_encode_updateCache(encodeState, cacheSlot, startingAtIndex, object); }
+  return(returnValue);
+}
+
+static int jk_encode_write(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object, const char *format) {
+  NSCParameterAssert((encodeState != NULL) && (encodeState->atIndex < encodeState->stringBuffer.bytes.length) && (startingAtIndex <= encodeState->atIndex) && (format != NULL));
+  if(JK_EXPECT_F(((encodeState->atIndex + strlen(format) + 256UL) > encodeState->stringBuffer.bytes.length)) && JK_EXPECT_F((jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + strlen(format) + 1024UL) == NULL))) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); }
+
+  size_t formatIdx = 0UL;
+  for(formatIdx = 0UL; format[formatIdx] != 0; formatIdx++) { NSCParameterAssert(encodeState->atIndex < encodeState->stringBuffer.bytes.length); encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = format[formatIdx]; }
+  jk_encode_updateCache(encodeState, cacheSlot, startingAtIndex, object);
+  return(0);
+}
+
+static int jk_encode_writePrettyPrintWhiteSpace(JKEncodeState *encodeState) {
+  NSCParameterAssert((encodeState != NULL) && ((encodeState->serializeOptionFlags & JKSerializeOptionPretty) != 0UL));
+  if(JK_EXPECT_F((encodeState->atIndex + ((encodeState->depth + 1UL) * 2UL) + 16UL) > encodeState->stringBuffer.bytes.length) && JK_EXPECT_T(jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + ((encodeState->depth + 1UL) * 2UL) + 4096UL) == NULL)) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); }
+  encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\n';
+  size_t depthWhiteSpace = 0UL;
+  for(depthWhiteSpace = 0UL; depthWhiteSpace < (encodeState->depth * 2UL); depthWhiteSpace++) { NSCParameterAssert(encodeState->atIndex < encodeState->stringBuffer.bytes.length); encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = ' '; }
+  return(0);
+}  
+
+static int jk_encode_write1slow(JKEncodeState *encodeState, ssize_t depthChange, const char *format) {
+  NSCParameterAssert((encodeState != NULL) && (encodeState->atIndex < encodeState->stringBuffer.bytes.length) && (format != NULL) && ((depthChange >= -1L) && (depthChange <= 1L)) && ((encodeState->depth == 0UL) ? (depthChange >= 0L) : 1) && ((encodeState->serializeOptionFlags & JKSerializeOptionPretty) != 0UL));
+  if(JK_EXPECT_F((encodeState->atIndex + ((encodeState->depth + 1UL) * 2UL) + 16UL) > encodeState->stringBuffer.bytes.length) && JK_EXPECT_F(jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + ((encodeState->depth + 1UL) * 2UL) + 4096UL) == NULL)) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); }
+  encodeState->depth += depthChange;
+  if(JK_EXPECT_T(format[0] == ':')) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = format[0]; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = ' '; }
+  else {
+    if(JK_EXPECT_F(depthChange == -1L)) { if(JK_EXPECT_F(jk_encode_writePrettyPrintWhiteSpace(encodeState))) { return(1); } }
+    encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = format[0];
+    if(JK_EXPECT_T(depthChange != -1L)) { if(JK_EXPECT_F(jk_encode_writePrettyPrintWhiteSpace(encodeState))) { return(1); } }
+  }
+  NSCParameterAssert(encodeState->atIndex < encodeState->stringBuffer.bytes.length);
+  return(0);
+}
+
+static int jk_encode_write1fast(JKEncodeState *encodeState, ssize_t depthChange JK_UNUSED_ARG, const char *format) {
+  NSCParameterAssert((encodeState != NULL) && (encodeState->atIndex < encodeState->stringBuffer.bytes.length) && ((encodeState->serializeOptionFlags & JKSerializeOptionPretty) == 0UL));
+  if(JK_EXPECT_T((encodeState->atIndex + 4UL) < encodeState->stringBuffer.bytes.length)) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = format[0]; }
+  else { return(jk_encode_write(encodeState, NULL, 0UL, NULL, format)); }
+  return(0);
+}
+
+static int jk_encode_writen(JKEncodeState *encodeState, JKEncodeCache *cacheSlot, size_t startingAtIndex, id object, const char *format, size_t length) {
+  NSCParameterAssert((encodeState != NULL) && (encodeState->atIndex < encodeState->stringBuffer.bytes.length) && (startingAtIndex <= encodeState->atIndex));
+  if(JK_EXPECT_F((encodeState->stringBuffer.bytes.length - encodeState->atIndex) < (length + 4UL))) { if(jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + 4096UL + length) == NULL) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); } }
+  memcpy(encodeState->stringBuffer.bytes.ptr + encodeState->atIndex, format, length);
+  encodeState->atIndex += length;
+  jk_encode_updateCache(encodeState, cacheSlot, startingAtIndex, object);
+  return(0);
+}
+
+JK_STATIC_INLINE JKHash jk_encode_object_hash(void *objectPtr) {
+  return( ( (((JKHash)objectPtr) >> 21) ^ (((JKHash)objectPtr) >> 9)   ) + (((JKHash)objectPtr) >> 4) );
+}
+
+static int jk_encode_add_atom_to_buffer(JKEncodeState *encodeState, void *objectPtr) {
+  NSCParameterAssert((encodeState != NULL) && (encodeState->atIndex < encodeState->stringBuffer.bytes.length) && (objectPtr != NULL));
+
+  id     object          = (id)objectPtr, encodeCacheObject = object;
+  int    isClass         = JKClassUnknown;
+  size_t startingAtIndex = encodeState->atIndex;
+
+  JKHash         objectHash = jk_encode_object_hash(objectPtr);
+  JKEncodeCache *cacheSlot  = &encodeState->cache[objectHash % JK_ENCODE_CACHE_SLOTS];
+
+  if(JK_EXPECT_T(cacheSlot->object == object)) {
+    NSCParameterAssert((cacheSlot->object != NULL) &&
+                       (cacheSlot->offset < encodeState->atIndex)                   && ((cacheSlot->offset + cacheSlot->length) < encodeState->atIndex)                                    &&
+                       (cacheSlot->offset < encodeState->stringBuffer.bytes.length) && ((cacheSlot->offset + cacheSlot->length) < encodeState->stringBuffer.bytes.length)                  &&
+                       ((encodeState->stringBuffer.bytes.ptr + encodeState->atIndex)                     < (encodeState->stringBuffer.bytes.ptr + encodeState->stringBuffer.bytes.length)) &&
+                       ((encodeState->stringBuffer.bytes.ptr + cacheSlot->offset)                        < (encodeState->stringBuffer.bytes.ptr + encodeState->stringBuffer.bytes.length)) &&
+                       ((encodeState->stringBuffer.bytes.ptr + cacheSlot->offset + cacheSlot->length)    < (encodeState->stringBuffer.bytes.ptr + encodeState->stringBuffer.bytes.length)));
+    if(JK_EXPECT_F(((encodeState->atIndex + cacheSlot->length + 256UL) > encodeState->stringBuffer.bytes.length)) && JK_EXPECT_F((jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + cacheSlot->length + 1024UL) == NULL))) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); }
+    NSCParameterAssert(((encodeState->atIndex + cacheSlot->length) < encodeState->stringBuffer.bytes.length) &&
+                       ((encodeState->stringBuffer.bytes.ptr + encodeState->atIndex)                     < (encodeState->stringBuffer.bytes.ptr + encodeState->stringBuffer.bytes.length)) &&
+                       ((encodeState->stringBuffer.bytes.ptr + encodeState->atIndex + cacheSlot->length) < (encodeState->stringBuffer.bytes.ptr + encodeState->stringBuffer.bytes.length)) &&
+                       ((encodeState->stringBuffer.bytes.ptr + cacheSlot->offset)                        < (encodeState->stringBuffer.bytes.ptr + encodeState->stringBuffer.bytes.length)) &&
+                       ((encodeState->stringBuffer.bytes.ptr + cacheSlot->offset + cacheSlot->length)    < (encodeState->stringBuffer.bytes.ptr + encodeState->stringBuffer.bytes.length)) &&
+                       ((encodeState->stringBuffer.bytes.ptr + cacheSlot->offset + cacheSlot->length)    < (encodeState->stringBuffer.bytes.ptr + encodeState->atIndex)));
+    memcpy(encodeState->stringBuffer.bytes.ptr + encodeState->atIndex, encodeState->stringBuffer.bytes.ptr + cacheSlot->offset, cacheSlot->length);
+    encodeState->atIndex += cacheSlot->length;
+    return(0);
+  }
+
+  // When we encounter a class that we do not handle, and we have either a delegate or block that the user supplied to format unsupported classes,
+  // we "re-run" the object check.  However, we re-run the object check exactly ONCE.  If the user supplies an object that isn't one of the
+  // supported classes, we fail the second type (i.e., double fault error).
+  BOOL rerunningAfterClassFormatter = NO;
+rerunAfterClassFormatter:
+       if(JK_EXPECT_T(object->isa == encodeState->fastClassLookup.stringClass))     { isClass = JKClassString;     }
+  else if(JK_EXPECT_T(object->isa == encodeState->fastClassLookup.numberClass))     { isClass = JKClassNumber;     }
+  else if(JK_EXPECT_T(object->isa == encodeState->fastClassLookup.dictionaryClass)) { isClass = JKClassDictionary; }
+  else if(JK_EXPECT_T(object->isa == encodeState->fastClassLookup.arrayClass))      { isClass = JKClassArray;      }
+  else if(JK_EXPECT_T(object->isa == encodeState->fastClassLookup.nullClass))       { isClass = JKClassNull;       }
+  else {
+         if(JK_EXPECT_T([object isKindOfClass:[NSString     class]])) { encodeState->fastClassLookup.stringClass     = object->isa; isClass = JKClassString;     }
+    else if(JK_EXPECT_T([object isKindOfClass:[NSNumber     class]])) { encodeState->fastClassLookup.numberClass     = object->isa; isClass = JKClassNumber;     }
+    else if(JK_EXPECT_T([object isKindOfClass:[NSDictionary class]])) { encodeState->fastClassLookup.dictionaryClass = object->isa; isClass = JKClassDictionary; }
+    else if(JK_EXPECT_T([object isKindOfClass:[NSArray      class]])) { encodeState->fastClassLookup.arrayClass      = object->isa; isClass = JKClassArray;      }
+    else if(JK_EXPECT_T([object isKindOfClass:[NSNull       class]])) { encodeState->fastClassLookup.nullClass       = object->isa; isClass = JKClassNull;       }
+    else {
+      if((rerunningAfterClassFormatter == NO) && (
+#ifdef __BLOCKS__
+           ((encodeState->classFormatterBlock) && ((object = encodeState->classFormatterBlock(object))                                                                         != NULL)) ||
+#endif
+           ((encodeState->classFormatterIMP)   && ((object = encodeState->classFormatterIMP(encodeState->classFormatterDelegate, encodeState->classFormatterSelector, object)) != NULL))    )) { rerunningAfterClassFormatter = YES; goto rerunAfterClassFormatter; }
+      
+      if(rerunningAfterClassFormatter == NO) { jk_encode_error(encodeState, @"Unable to serialize object class %@.", NSStringFromClass([encodeCacheObject class])); return(1); }
+      else { jk_encode_error(encodeState, @"Unable to serialize object class %@ that was returned by the unsupported class formatter.  Original object class was %@.", (object == NULL) ? @"NULL" : NSStringFromClass([object class]), NSStringFromClass([encodeCacheObject class])); return(1); }
+    }
+  }
+
+  // This is here for the benefit of the optimizer.  It allows the optimizer to do loop invariant code motion for the JKClassArray
+  // and JKClassDictionary cases when printing simple, single characters via jk_encode_write(), which is actually a macro:
+  // #define jk_encode_write1(es, dc, f) (_jk_encode_prettyPrint ? jk_encode_write1slow(es, dc, f) : jk_encode_write1fast(es, dc, f))
+  int _jk_encode_prettyPrint = JK_EXPECT_T((encodeState->serializeOptionFlags & JKSerializeOptionPretty) == 0) ? 0 : 1;
+  
+  switch(isClass) {
+    case JKClassString:
+      {
+        {
+          const unsigned char *cStringPtr = (const unsigned char *)CFStringGetCStringPtr((CFStringRef)object, kCFStringEncodingMacRoman);
+          if(cStringPtr != NULL) {
+            const unsigned char *utf8String = cStringPtr;
+            size_t               utf8Idx    = 0UL;
+
+            CFIndex stringLength = CFStringGetLength((CFStringRef)object);
+            if(JK_EXPECT_F(((encodeState->atIndex + (stringLength * 2UL) + 256UL) > encodeState->stringBuffer.bytes.length)) && JK_EXPECT_F((jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + (stringLength * 2UL) + 1024UL) == NULL))) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); }
+
+            if(JK_EXPECT_T((encodeState->encodeOption & JKEncodeOptionStringObjTrimQuotes) == 0UL)) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\"'; }
+            for(utf8Idx = 0UL; utf8String[utf8Idx] != 0U; utf8Idx++) {
+              NSCParameterAssert(((&encodeState->stringBuffer.bytes.ptr[encodeState->atIndex]) - encodeState->stringBuffer.bytes.ptr) < (ssize_t)encodeState->stringBuffer.bytes.length);
+              NSCParameterAssert(encodeState->atIndex < encodeState->stringBuffer.bytes.length);
+              if(JK_EXPECT_F(utf8String[utf8Idx] >= 0x80U)) { encodeState->atIndex = startingAtIndex; goto slowUTF8Path; }
+              if(JK_EXPECT_F(utf8String[utf8Idx] <  0x20U)) {
+                switch(utf8String[utf8Idx]) {
+                  case '\b': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'b'; break;
+                  case '\f': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'f'; break;
+                  case '\n': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'n'; break;
+                  case '\r': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'r'; break;
+                  case '\t': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 't'; break;
+                  default: if(JK_EXPECT_F(jk_encode_printf(encodeState, NULL, 0UL, NULL, "\\u%4.4x", utf8String[utf8Idx]))) { return(1); } break;
+                }
+              } else {
+                if(JK_EXPECT_F(utf8String[utf8Idx] == '\"') || JK_EXPECT_F(utf8String[utf8Idx] == '\\') || (JK_EXPECT_F(encodeState->serializeOptionFlags & JKSerializeOptionEscapeForwardSlashes) && JK_EXPECT_F(utf8String[utf8Idx] == '/'))) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; }
+                encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = utf8String[utf8Idx];
+              }
+            }
+            NSCParameterAssert((encodeState->atIndex + 1UL) < encodeState->stringBuffer.bytes.length);
+            if(JK_EXPECT_T((encodeState->encodeOption & JKEncodeOptionStringObjTrimQuotes) == 0UL)) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\"'; }
+            jk_encode_updateCache(encodeState, cacheSlot, startingAtIndex, encodeCacheObject);
+            return(0);
+          }
+        }
+
+      slowUTF8Path:
+        {
+          CFIndex stringLength        = CFStringGetLength((CFStringRef)object);
+          CFIndex maxStringUTF8Length = CFStringGetMaximumSizeForEncoding(stringLength, kCFStringEncodingUTF8) + 32L;
+        
+          if(JK_EXPECT_F((size_t)maxStringUTF8Length > encodeState->utf8ConversionBuffer.bytes.length) && JK_EXPECT_F(jk_managedBuffer_resize(&encodeState->utf8ConversionBuffer, maxStringUTF8Length + 1024UL) == NULL)) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); }
+        
+          CFIndex usedBytes = 0L, convertedCount = 0L;
+          convertedCount = CFStringGetBytes((CFStringRef)object, CFRangeMake(0L, stringLength), kCFStringEncodingUTF8, '?', NO, encodeState->utf8ConversionBuffer.bytes.ptr, encodeState->utf8ConversionBuffer.bytes.length - 16L, &usedBytes);
+          if(JK_EXPECT_F(convertedCount != stringLength) || JK_EXPECT_F(usedBytes < 0L)) { jk_encode_error(encodeState, @"An error occurred converting the contents of a NSString to UTF8."); return(1); }
+        
+          if(JK_EXPECT_F((encodeState->atIndex + (maxStringUTF8Length * 2UL) + 256UL) > encodeState->stringBuffer.bytes.length) && JK_EXPECT_F(jk_managedBuffer_resize(&encodeState->stringBuffer, encodeState->atIndex + (maxStringUTF8Length * 2UL) + 1024UL) == NULL)) { jk_encode_error(encodeState, @"Unable to resize temporary buffer."); return(1); }
+        
+          const unsigned char *utf8String = encodeState->utf8ConversionBuffer.bytes.ptr;
+        
+          size_t utf8Idx = 0UL;
+          if(JK_EXPECT_T((encodeState->encodeOption & JKEncodeOptionStringObjTrimQuotes) == 0UL)) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\"'; }
+          for(utf8Idx = 0UL; utf8Idx < (size_t)usedBytes; utf8Idx++) {
+            NSCParameterAssert(((&encodeState->stringBuffer.bytes.ptr[encodeState->atIndex]) - encodeState->stringBuffer.bytes.ptr) < (ssize_t)encodeState->stringBuffer.bytes.length);
+            NSCParameterAssert(encodeState->atIndex < encodeState->stringBuffer.bytes.length);
+            NSCParameterAssert((CFIndex)utf8Idx < usedBytes);
+            if(JK_EXPECT_F(utf8String[utf8Idx] < 0x20U)) {
+              switch(utf8String[utf8Idx]) {
+                case '\b': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'b'; break;
+                case '\f': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'f'; break;
+                case '\n': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'n'; break;
+                case '\r': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 'r'; break;
+                case '\t': encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = 't'; break;
+                default: if(JK_EXPECT_F(jk_encode_printf(encodeState, NULL, 0UL, NULL, "\\u%4.4x", utf8String[utf8Idx]))) { return(1); } break;
+              }
+            } else {
+              if(JK_EXPECT_F(utf8String[utf8Idx] >= 0x80U) && (encodeState->serializeOptionFlags & JKSerializeOptionEscapeUnicode)) {
+                const unsigned char *nextValidCharacter = NULL;
+                UTF32                u32ch              = 0U;
+                ConversionResult     result;
+
+                if(JK_EXPECT_F((result = ConvertSingleCodePointInUTF8(&utf8String[utf8Idx], &utf8String[usedBytes], (UTF8 const **)&nextValidCharacter, &u32ch)) != conversionOK)) { jk_encode_error(encodeState, @"Error converting UTF8."); return(1); }
+                else {
+                  utf8Idx = (nextValidCharacter - utf8String) - 1UL;
+                  if(JK_EXPECT_T(u32ch <= 0xffffU)) { if(JK_EXPECT_F(jk_encode_printf(encodeState, NULL, 0UL, NULL, "\\u%4.4x", u32ch)))                                                           { return(1); } }
+                  else                              { if(JK_EXPECT_F(jk_encode_printf(encodeState, NULL, 0UL, NULL, "\\u%4.4x\\u%4.4x", (0xd7c0U + (u32ch >> 10)), (0xdc00U + (u32ch & 0x3ffU))))) { return(1); } }
+                }
+              } else {
+                if(JK_EXPECT_F(utf8String[utf8Idx] == '\"') || JK_EXPECT_F(utf8String[utf8Idx] == '\\') || (JK_EXPECT_F(encodeState->serializeOptionFlags & JKSerializeOptionEscapeForwardSlashes) && JK_EXPECT_F(utf8String[utf8Idx] == '/'))) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\\'; }
+                encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = utf8String[utf8Idx];
+              }
+            }
+          }
+          NSCParameterAssert((encodeState->atIndex + 1UL) < encodeState->stringBuffer.bytes.length);
+          if(JK_EXPECT_T((encodeState->encodeOption & JKEncodeOptionStringObjTrimQuotes) == 0UL)) { encodeState->stringBuffer.bytes.ptr[encodeState->atIndex++] = '\"'; }
+          jk_encode_updateCache(encodeState, cacheSlot, startingAtIndex, encodeCacheObject);
+          return(0);
+        }
+      }
+      break;
+
+    case JKClassNumber:
+      {
+             if(object == (id)kCFBooleanTrue)  { return(jk_encode_writen(encodeState, cacheSlot, startingAtIndex, encodeCacheObject, "true",  4UL)); }
+        else if(object == (id)kCFBooleanFalse) { return(jk_encode_writen(encodeState, cacheSlot, startingAtIndex, encodeCacheObject, "false", 5UL)); }
+        
+        const char         *objCType = [object objCType];
+        char                anum[256], *aptr = &anum[255];
+        int                 isNegative = 0;
+        unsigned long long  ullv;
+        long long           llv;
+        
+        if(JK_EXPECT_F(objCType == NULL) || JK_EXPECT_F(objCType[0] == 0) || JK_EXPECT_F(objCType[1] != 0)) { jk_encode_error(encodeState, @"NSNumber conversion error, unknown type.  Type: '%s'", (objCType == NULL) ? "<NULL>" : objCType); return(1); }
+        
+        switch(objCType[0]) {
+          case 'c': case 'i': case 's': case 'l': case 'q':
+            if(JK_EXPECT_T(CFNumberGetValue((CFNumberRef)object, kCFNumberLongLongType, &llv)))  {
+              if(llv < 0LL)  { ullv = -llv; isNegative = 1; } else { ullv = llv; isNegative = 0; }
+              goto convertNumber;
+            } else { jk_encode_error(encodeState, @"Unable to get scalar value from number object."); return(1); }
+            break;
+          case 'C': case 'I': case 'S': case 'L': case 'Q': case 'B':
+            if(JK_EXPECT_T(CFNumberGetValue((CFNumberRef)object, kCFNumberLongLongType, &ullv))) {
+            convertNumber:
+              if(JK_EXPECT_F(ullv < 10ULL)) { *--aptr = ullv + '0'; } else { while(JK_EXPECT_T(ullv > 0ULL)) { *--aptr = (ullv % 10ULL) + '0'; ullv /= 10ULL; NSCParameterAssert(aptr > anum); } }
+              if(isNegative) { *--aptr = '-'; }
+              NSCParameterAssert(aptr > anum);
+              return(jk_encode_writen(encodeState, cacheSlot, startingAtIndex, encodeCacheObject, aptr, &anum[255] - aptr));
+            } else { jk_encode_error(encodeState, @"Unable to get scalar value from number object."); return(1); }
+            break;
+          case 'f': case 'd':
+            {
+              double dv;
+              if(JK_EXPECT_T(CFNumberGetValue((CFNumberRef)object, kCFNumberDoubleType, &dv))) {
+                if(JK_EXPECT_F(!isfinite(dv))) { jk_encode_error(encodeState, @"Floating point values must be finite.  JSON does not support NaN or Infinity."); return(1); }
+                return(jk_encode_printf(encodeState, cacheSlot, startingAtIndex, encodeCacheObject, "%.17g", dv));
+              } else { jk_encode_error(encodeState, @"Unable to get floating point value from number object."); return(1); }
+            }
+            break;
+          default: jk_encode_error(encodeState, @"NSNumber conversion error, unknown type.  Type: '%c' / 0x%2.2x", objCType[0], objCType[0]); return(1); break;
+        }
+      }
+      break;
+    
+    case JKClassArray:
+      {
+        int     printComma = 0;
+        CFIndex arrayCount = CFArrayGetCount((CFArrayRef)object), idx = 0L;
+        if(JK_EXPECT_F(jk_encode_write1(encodeState, 1L, "["))) { return(1); }
+        if(JK_EXPECT_F(arrayCount > 1020L)) {
+          for(id arrayObject in object)          { if(JK_EXPECT_T(printComma)) { if(JK_EXPECT_F(jk_encode_write1(encodeState, 0L, ","))) { return(1); } } printComma = 1; if(JK_EXPECT_F(jk_encode_add_atom_to_buffer(encodeState, arrayObject)))  { return(1); } }
+        } else {
+          void *objects[1024];
+          CFArrayGetValues((CFArrayRef)object, CFRangeMake(0L, arrayCount), (const void **)objects);
+          for(idx = 0L; idx < arrayCount; idx++) { if(JK_EXPECT_T(printComma)) { if(JK_EXPECT_F(jk_encode_write1(encodeState, 0L, ","))) { return(1); } } printComma = 1; if(JK_EXPECT_F(jk_encode_add_atom_to_buffer(encodeState, objects[idx]))) { return(1); } }
+        }
+        return(jk_encode_write1(encodeState, -1L, "]"));
+      }
+      break;
+
+    case JKClassDictionary:
+      {
+        int     printComma      = 0;
+        CFIndex dictionaryCount = CFDictionaryGetCount((CFDictionaryRef)object), idx = 0L;
+        id      enumerateObject = JK_EXPECT_F(_jk_encode_prettyPrint) ? [[object allKeys] sortedArrayUsingSelector:@selector(compare:)] : object;
+
+        if(JK_EXPECT_F(jk_encode_write1(encodeState, 1L, "{"))) { return(1); }
+        if(JK_EXPECT_F(_jk_encode_prettyPrint) || JK_EXPECT_F(dictionaryCount > 1020L)) {
+          for(id keyObject in enumerateObject) {
+            if(JK_EXPECT_T(printComma)) { if(JK_EXPECT_F(jk_encode_write1(encodeState, 0L, ","))) { return(1); } }
+            printComma = 1;
+            if(JK_EXPECT_F((keyObject->isa      != encodeState->fastClassLookup.stringClass)) && JK_EXPECT_F(([keyObject   isKindOfClass:[NSString class]] == NO))) { jk_encode_error(encodeState, @"Key must be a string object."); return(1); }
+            if(JK_EXPECT_F(jk_encode_add_atom_to_buffer(encodeState, keyObject)))                                                        { return(1); }
+            if(JK_EXPECT_F(jk_encode_write1(encodeState, 0L, ":")))                                                                      { return(1); }
+            if(JK_EXPECT_F(jk_encode_add_atom_to_buffer(encodeState, (void *)CFDictionaryGetValue((CFDictionaryRef)object, keyObject)))) { return(1); }
+          }
+        } else {
+          void *keys[1024], *objects[1024];
+          CFDictionaryGetKeysAndValues((CFDictionaryRef)object, (const void **)keys, (const void **)objects);
+          for(idx = 0L; idx < dictionaryCount; idx++) {
+            if(JK_EXPECT_T(printComma)) { if(JK_EXPECT_F(jk_encode_write1(encodeState, 0L, ","))) { return(1); } }
+            printComma = 1;
+            if(JK_EXPECT_F(((id)keys[idx])->isa != encodeState->fastClassLookup.stringClass) && JK_EXPECT_F([(id)keys[idx] isKindOfClass:[NSString class]] == NO)) { jk_encode_error(encodeState, @"Key must be a string object."); return(1); }
+            if(JK_EXPECT_F(jk_encode_add_atom_to_buffer(encodeState, keys[idx])))    { return(1); }
+            if(JK_EXPECT_F(jk_encode_write1(encodeState, 0L, ":")))                  { return(1); }
+            if(JK_EXPECT_F(jk_encode_add_atom_to_buffer(encodeState, objects[idx]))) { return(1); }
+          }
+        }
+        return(jk_encode_write1(encodeState, -1L, "}"));
+      }
+      break;
+
+    case JKClassNull: return(jk_encode_writen(encodeState, cacheSlot, startingAtIndex, encodeCacheObject, "null", 4UL)); break;
+
+    default: jk_encode_error(encodeState, @"Unable to serialize object class %@.", NSStringFromClass([object class])); return(1); break;
+  }
+
+  return(0);
+}
+
+
+@implementation JKSerializer
+
++ (id)serializeObject:(id)object options:(JKSerializeOptionFlags)optionFlags encodeOption:(JKEncodeOptionType)encodeOption block:(JKSERIALIZER_BLOCKS_PROTO)block delegate:(id)delegate selector:(SEL)selector error:(NSError **)error
+{
+  return([[[[self alloc] init] autorelease] serializeObject:object options:optionFlags encodeOption:encodeOption block:block delegate:delegate selector:selector error:error]);
+}
+
+- (id)serializeObject:(id)object options:(JKSerializeOptionFlags)optionFlags encodeOption:(JKEncodeOptionType)encodeOption block:(JKSERIALIZER_BLOCKS_PROTO)block delegate:(id)delegate selector:(SEL)selector error:(NSError **)error
+{
+#ifndef __BLOCKS__
+#pragma unused(block)
+#endif
+  NSParameterAssert((object != NULL) && (encodeState == NULL) && ((delegate != NULL) ? (block == NULL) : 1) && ((block != NULL) ? (delegate == NULL) : 1) &&
+                    (((encodeOption & JKEncodeOptionCollectionObj) != 0UL) ? (((encodeOption & JKEncodeOptionStringObj)     == 0UL) && ((encodeOption & JKEncodeOptionStringObjTrimQuotes) == 0UL)) : 1) &&
+                    (((encodeOption & JKEncodeOptionStringObj)     != 0UL) ?  ((encodeOption & JKEncodeOptionCollectionObj) == 0UL)                                                                 : 1));
+
+  id returnObject = NULL;
+
+  if(encodeState != NULL) { [self releaseState]; }
+  if((encodeState = (struct JKEncodeState *)calloc(1UL, sizeof(JKEncodeState))) == NULL) { [NSException raise:NSMallocException format:@"Unable to allocate state structure."]; return(NULL); }
+
+  if((error != NULL) && (*error != NULL)) { *error = NULL; }
+
+  if(delegate != NULL) {
+    if(selector                               == NULL) { [NSException raise:NSInvalidArgumentException format:@"The delegate argument is not NULL, but the selector argument is NULL."]; }
+    if([delegate respondsToSelector:selector] == NO)   { [NSException raise:NSInvalidArgumentException format:@"The serializeUnsupportedClassesUsingDelegate: delegate does not respond to the selector argument."]; }
+    encodeState->classFormatterDelegate = delegate;
+    encodeState->classFormatterSelector = selector;
+    encodeState->classFormatterIMP      = (JKClassFormatterIMP)[delegate methodForSelector:selector];
+    NSCParameterAssert(encodeState->classFormatterIMP != NULL);
+  }
+
+#ifdef __BLOCKS__
+  encodeState->classFormatterBlock                          = block;
+#endif
+  encodeState->serializeOptionFlags                         = optionFlags;
+  encodeState->encodeOption                                 = encodeOption;
+  encodeState->stringBuffer.roundSizeUpToMultipleOf         = (1024UL * 32UL);
+  encodeState->utf8ConversionBuffer.roundSizeUpToMultipleOf = 4096UL;
+    
+  unsigned char stackJSONBuffer[JK_JSONBUFFER_SIZE] JK_ALIGNED(64);
+  jk_managedBuffer_setToStackBuffer(&encodeState->stringBuffer,         stackJSONBuffer, sizeof(stackJSONBuffer));
+
+  unsigned char stackUTF8Buffer[JK_UTF8BUFFER_SIZE] JK_ALIGNED(64);
+  jk_managedBuffer_setToStackBuffer(&encodeState->utf8ConversionBuffer, stackUTF8Buffer, sizeof(stackUTF8Buffer));
+
+  if(((encodeOption & JKEncodeOptionCollectionObj) != 0UL) && (([object isKindOfClass:[NSArray  class]] == NO) && ([object isKindOfClass:[NSDictionary class]] == NO))) { jk_encode_error(encodeState, @"Unable to serialize object class %@, expected a NSArray or NSDictionary.", NSStringFromClass([object class])); goto errorExit; }
+  if(((encodeOption & JKEncodeOptionStringObj)     != 0UL) &&  ([object isKindOfClass:[NSString class]] == NO))                                                         { jk_encode_error(encodeState, @"Unable to serialize object class %@, expected a NSString.", NSStringFromClass([object class])); goto errorExit; }
+
+  if(jk_encode_add_atom_to_buffer(encodeState, object) == 0) {
+    BOOL stackBuffer = ((encodeState->stringBuffer.flags & JKManagedBufferMustFree) == 0UL) ? YES : NO;
+    
+    if((encodeState->atIndex < 2UL))
+    if((stackBuffer == NO) && ((encodeState->stringBuffer.bytes.ptr = (unsigned char *)reallocf(encodeState->stringBuffer.bytes.ptr, encodeState->atIndex + 16UL)) == NULL)) { jk_encode_error(encodeState, @"Unable to realloc buffer"); goto errorExit; }
+
+    switch((encodeOption & JKEncodeOptionAsTypeMask)) {
+      case JKEncodeOptionAsData:
+        if(stackBuffer == YES) { if((returnObject = [(id)CFDataCreate(                 NULL,                encodeState->stringBuffer.bytes.ptr, (CFIndex)encodeState->atIndex)                                  autorelease]) == NULL) { jk_encode_error(encodeState, @"Unable to create NSData object"); } }
+        else                   { if((returnObject = [(id)CFDataCreateWithBytesNoCopy(  NULL,                encodeState->stringBuffer.bytes.ptr, (CFIndex)encodeState->atIndex, NULL)                            autorelease]) == NULL) { jk_encode_error(encodeState, @"Unable to create NSData object"); } }
+        break;
+
+      case JKEncodeOptionAsString:
+        if(stackBuffer == YES) { if((returnObject = [(id)CFStringCreateWithBytes(      NULL, (const UInt8 *)encodeState->stringBuffer.bytes.ptr, (CFIndex)encodeState->atIndex, kCFStringEncodingUTF8, NO)       autorelease]) == NULL) { jk_encode_error(encodeState, @"Unable to create NSString object"); } }
+        else                   { if((returnObject = [(id)CFStringCreateWithBytesNoCopy(NULL, (const UInt8 *)encodeState->stringBuffer.bytes.ptr, (CFIndex)encodeState->atIndex, kCFStringEncodingUTF8, NO, NULL) autorelease]) == NULL) { jk_encode_error(encodeState, @"Unable to create NSString object"); } }
+        break;
+
+      default: jk_encode_error(encodeState, @"Unknown encode as type."); break;
+    }
+
+    if((returnObject != NULL) && (stackBuffer == NO)) { encodeState->stringBuffer.flags &= ~JKManagedBufferMustFree; encodeState->stringBuffer.bytes.ptr = NULL; encodeState->stringBuffer.bytes.length = 0UL; }
+  }
+
+errorExit:
+  if((encodeState != NULL) && (error != NULL) && (encodeState->error != NULL)) { *error = encodeState->error; encodeState->error = NULL; }
+  [self releaseState];
+
+  return(returnObject);
+}
+
+- (void)releaseState
+{
+  if(encodeState != NULL) {
+    jk_managedBuffer_release(&encodeState->stringBuffer);
+    jk_managedBuffer_release(&encodeState->utf8ConversionBuffer);
+    free(encodeState); encodeState = NULL;
+  }  
+}
+
+- (void)dealloc
+{
+  [self releaseState];
+  [super dealloc];
+}
+
+@end
+
+@implementation NSString (JSONKitSerializing)
+
+////////////
+#pragma mark Methods for serializing a single NSString.
+////////////
+
+// Useful for those who need to serialize just a NSString.  Otherwise you would have to do something like [NSArray arrayWithObject:stringToBeJSONSerialized], serializing the array, and then chopping of the extra ^\[.*\]$ square brackets.
+
+// NSData returning methods...
+
+- (NSData *)JSONData
+{
+  return([self JSONDataWithOptions:JKSerializeOptionNone includeQuotes:YES error:NULL]);
+}
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsData | ((includeQuotes == NO) ? JKEncodeOptionStringObjTrimQuotes : 0UL) | JKEncodeOptionStringObj) block:NULL delegate:NULL selector:NULL error:error]);
+}
+
+// NSString returning methods...
+
+- (NSString *)JSONString
+{
+  return([self JSONStringWithOptions:JKSerializeOptionNone includeQuotes:YES error:NULL]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsString | ((includeQuotes == NO) ? JKEncodeOptionStringObjTrimQuotes : 0UL) | JKEncodeOptionStringObj) block:NULL delegate:NULL selector:NULL error:error]);
+}
+
+@end
+
+@implementation NSArray (JSONKitSerializing)
+
+// NSData returning methods...
+
+- (NSData *)JSONData
+{
+  return([JKSerializer serializeObject:self options:JKSerializeOptionNone encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:NULL]);
+}
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:error]);
+}
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:NULL delegate:delegate selector:selector error:error]);
+}
+
+// NSString returning methods...
+
+- (NSString *)JSONString
+{
+  return([JKSerializer serializeObject:self options:JKSerializeOptionNone encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:NULL]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:error]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:NULL delegate:delegate selector:selector error:error]);
+}
+
+@end
+
+@implementation NSDictionary (JSONKitSerializing)
+
+// NSData returning methods...
+
+- (NSData *)JSONData
+{
+  return([JKSerializer serializeObject:self options:JKSerializeOptionNone encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:NULL]);
+}
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:error]);
+}
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:NULL delegate:delegate selector:selector error:error]);
+}
+
+// NSString returning methods...
+
+- (NSString *)JSONString
+{
+  return([JKSerializer serializeObject:self options:JKSerializeOptionNone encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:NULL]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:NULL delegate:NULL selector:NULL error:error]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingDelegate:(id)delegate selector:(SEL)selector error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:NULL delegate:delegate selector:selector error:error]);
+}
+
+@end
+
+
+#ifdef __BLOCKS__
+
+@implementation NSArray (JSONKitSerializingBlockAdditions)
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:block delegate:NULL selector:NULL error:error]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:block delegate:NULL selector:NULL error:error]);
+}
+
+@end
+
+@implementation NSDictionary (JSONKitSerializingBlockAdditions)
+
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsData | JKEncodeOptionCollectionObj) block:block delegate:NULL selector:NULL error:error]);
+}
+
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions serializeUnsupportedClassesUsingBlock:(id(^)(id object))block error:(NSError **)error
+{
+  return([JKSerializer serializeObject:self options:serializeOptions encodeOption:(JKEncodeOptionAsString | JKEncodeOptionCollectionObj) block:block delegate:NULL selector:NULL error:error]);
+}
+
+@end
+
+#endif // __BLOCKS__
+

--- a/MapView/Map/JSONKit/README.md
+++ b/MapView/Map/JSONKit/README.md
@@ -1,0 +1,307 @@
+# JSONKit
+
+JSONKit is dual licensed under either the terms of the BSD License, or alternatively under the terms of the Apache License, Version 2.0.<br />
+Copyright &copy; 2011, John Engelhart.
+
+### A Very High Performance Objective-C JSON Library
+
+  Parsing  |  Serializing
+:---------:|:-------------:
+<img src="http://chart.googleapis.com/chart?chf=a,s,000000%7Cb0,lg,0,6589C760,0,6589C7B4,1%7Cbg,lg,90,EFEFEF,0,F8F8F8,1&chxl=0:%7CTouchJSON%7CXML+.plist%7Cjson-framework%7CYAJL-ObjC%7Cgzip+JSONKit%7CBinary+.plist%7CJSONKit%7C2:%7CTime+to+Deserialize+in+%C2%B5sec&chxp=2,40&chxr=0,0,5%7C1,0,3250&chxs=0,676767,11.5,1,lt,676767&chxt=y,x,x&chbh=a,5,4&chs=350x185&cht=bhs&chco=6589C783&chds=0,3250&chd=t:410.517,510.262,539.614,1351.257,1683.346,1747.953,2955.881&chg=-1,0,1,3&chm=N+*s*+%C2%B5s,676767,0,0:5,10.5%7CN+*s*+%C2%B5s,3d3d3d,0,6,10.5,,r:-5:1&chem=y;s=text_outline;d=666,10.5,l,fff,_,Decompress+%2b+Parse+is+just;ds=0;dp=2;py=0;of=58,7%7Cy;s=text_outline;d=666,10.5,l,fff,_,5.6%25+slower+than+Binary+.plist%21;ds=0;dp=2;py=0;of=53,-5" width="350" height="185" alt="Deserialize from JSON" /> | <img src="http://chart.googleapis.com/chart?chf=a,s,000000%7Cb0,lg,0,699E7260,0,699E72B4,1%7Cbg,lg,90,EFEFEF,0,F8F8F8,1&chxl=0:%7CTouchJSON%7CYAJL-ObjC%7CXML+.plist%7Cjson-framework%7CBinary+.plist%7Cgzip+JSONKit%7CJSONKit%7C2:%7CTime+to+Serialize+in+%C2%B5sec&chxp=2,40&chxr=0,0,5%7C1,0,3250&chxs=0,676767,11.5,1,lt,676767&chxt=y,x,x&chbh=a,5,4&chs=350x175&cht=bhs&chco=699E7284&chds=0,3250&chd=t:96.387,466.947,626.153,1028.432,1945.511,2156.978,3051.976&chg=-1,0,1,3&chm=N+*s*+%C2%B5s,676767,0,0:5,10.5%7CN+*s*+%C2%B5s,4d4d4d,0,6,10.5,,r:-5:1&chem=y;s=text_outline;d=666,10.5,l,fff,_,Serialize+%2b+Compress+is+34%25;ds=0;dp=1;py=0;of=51,7%7Cy;s=text_outline;d=666,10.5,l,fff,_,faster+than+Binary+.plist%21;ds=0;dp=1;py=0;of=62,-5" width="350" height="185" alt="Serialize to JSON" />
+*23% Faster than Binary* <code><em>.plist</em></code>*&thinsp;!* | *549% Faster than Binary* <code><em>.plist</em></code>*&thinsp;!*
+
+* Benchmarking was performed on a MacBook Pro with a 2.66GHz Core 2.
+* All JSON libraries were compiled with `gcc-4.2 -DNS_BLOCK_ASSERTIONS -O3 -arch x86_64`.
+* Timing results are the average of 1,000 iterations of the user + system time reported by [`getrusage`][getrusage].
+* The JSON used was [`twitter_public_timeline.json`](https://github.com/samsoffes/json-benchmarks/blob/master/Resources/twitter_public_timeline.json) from [samsoffes / json-benchmarks](https://github.com/samsoffes/json-benchmarks).
+* Since the `.plist` format does not support serializing [`NSNull`][NSNull], the `null` values in the original JSON were changed to `"null"`.
+* The [experimental](https://github.com/johnezang/JSONKit/tree/experimental) branch contains the `gzip` compression changes.
+    * JSONKit automagically links to `libz.dylib` on the fly at run time&ndash; no manual linking required.
+    * Parsing / deserializing will automagically decompress a buffer if it detects a `gzip` signature header.
+    * You can compress / `gzip` the serialized JSON by passing `JKSerializeOptionCompress` to `-JSONDataWithOptions:error:`.
+
+[JSON versus PLIST, the Ultimate Showdown](http://www.cocoanetics.com/2011/03/json-versus-plist-the-ultimate-showdown/) benchmarks the common JSON libraries and compares them to Apples `.plist` format.
+
+***
+
+JavaScript Object Notation, or [JSON][], is a lightweight, text-based, serialization format for structured data that is used by many web-based services and API's.  It is defined by [RFC 4627][].
+
+JSON provides the following primitive types:
+
+* `null`
+* Boolean `true` and `false`
+* Number
+* String
+* Array
+* Object (a.k.a. Associative Arrays, Key / Value Hash Tables, Maps, Dictionaries, etc.)
+
+These primitive types are mapped to the following Objective-C Foundation classes:
+
+JSON               | Objective-C
+-------------------|-------------
+`null`             | [`NSNull`][NSNull]
+`true` and `false` | [`NSNumber`][NSNumber]
+Number             | [`NSNumber`][NSNumber]
+String             | [`NSString`][NSString]
+Array              | [`NSArray`][NSArray]
+Object             | [`NSDictionary`][NSDictionary]
+
+JSONKit uses Core Foundation internally, and it is assumed that Core Foundation &equiv; Foundation for every equivalent base type, i.e. [`CFString`][CFString] &equiv; [`NSString`][NSString].
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
+
+### JSON To Objective-C Primitive Mapping Details
+
+*   The [JSON specification][RFC 4627] is somewhat ambiguous about the details and requirements when it comes to Unicode, and it does not specify how Unicode issues and errors should be handled.  Most of the ambiguity stems from the interpretation and scope [RFC 4627][] Section 3, Encoding: `JSON text SHALL be encoded in Unicode.`  It is the authors opinion and interpretation that the language of [RFC 4627][] requires that a JSON implementation MUST follow the requirements specified in the [Unicode Standard][], and in particular the [Conformance][Unicode Standard - Conformance] chapter of the [Unicode Standard][], which specifies requirements related to handling, interpreting, and manipulating Unicode text.
+    
+    The default behavior for JSONKit is strict [RFC 4627][] conformance.  It is the authors opinion and interpretation that [RFC 4627][] requires JSON to be encoded in Unicode, and therefore JSON that is not legal Unicode as defined by the [Unicode Standard][] is invalid JSON.  Therefore, JSONKit will not accept JSON that contains ill-formed Unicode.  The default, strict behavior implies that the `JKParseOptionLooseUnicode` option is not enabled.
+    
+    When the `JKParseOptionLooseUnicode` option is enabled, JSONKit follows the specifications and recommendations given in [The Unicode 6.0 standard, Chapter 3 - Conformance][Unicode Standard - Conformance], section 3.9 *Unicode Encoding Forms*.  As a general rule of thumb, the Unicode code point `U+FFFD` is substituted for any ill-formed Unicode encountered. JSONKit attempts to follow the recommended *Best Practice for Using U+FFFD*:  ***Replace each maximal subpart of an ill-formed subsequence by a single U+FFFD.***
+    
+    The following Unicode code points are treated as ill-formed Unicode, and if `JKParseOptionLooseUnicode` is enabled, cause `U+FFFD` to be substituted in their place:
+
+    `U+0000`.<br>
+    `U+D800` thru `U+DFFF`, inclusive.<br>
+    `U+FDD0` thru `U+FDEF`, inclusive.<br>
+    <code>U+<i>n</i>FFFE</code> and <code>U+<i>n</i>FFFF</code>, where *n* is from `0x0` to `0x10`
+
+    The code points `U+FDD0` thru `U+FDEF`, <code>U+<i>n</i>FFFE</code>, and <code>U+<i>n</i>FFFF</code> (where *n* is from `0x0` to `0x10`), are defined as ***Noncharacters*** by the Unicode standard and "should never be interchanged".
+    
+    An exception is made for the code point `U+0000`, which is legal Unicode.  The reason for this is that this particular code point is used by C string handling code to specify the end of the string, and any such string handling code will incorrectly stop processing a string at the point where `U+0000` occurs.  Although reasonable people may have different opinions on this point, it is the authors considered opinion that the risks of permitting JSON Strings that contain `U+0000` outweigh the benefits.  One of the risks in allowing `U+0000` to appear unaltered in a string is that it has the potential to create security problems by subtly altering the semantics of the string which can then be exploited by a malicious attacker.  This is similar to the issue of [arbitrarily deleting characters from Unicode text][Unicode_UTR36_Deleting].
+    
+    [RFC 4627][] allows for these limitations under section 4, Parsers: `An implementation may set limits on the length and character contents of strings.`  While the [Unicode Standard][] permits the mutation of the original JSON (i.e., substituting `U+FFFD` for ill-formed Unicode), [RFC 4627][] is silent on this issue.  It is the authors opinion and interpretation that [RFC 4627][], section 3 &ndash; *Encoding*, `JSON text SHALL be encoded in Unicode.` implies that such mutations are not only permitted but MUST be expected by any strictly conforming [RFC 4627][] JSON implementation.  The author feels obligated to note that this opinion and interpretation may not be shared by others and, in fact, may be a minority opinion and interpretation.  You should be aware that any mutation of the original JSON may subtly alter its semantics and, as a result, may have security related implications for anything that consumes the final result.
+    
+    It is important to note that JSONKit will not delete characters from the JSON being parsed as this is a [requirement specified by the Unicode Standard][Unicode_UTR36_Deleting].  Additional information can be found in the [Unicode Security FAQ][Unicode_Security_FAQ] and [Unicode Technical Report #36 - Unicode Security Consideration][Unicode_UTR36], in particular the section on [non-visual security][Unicode_UTR36_NonVisualSecurity].
+
+*   The [JSON specification][RFC 4627] does not specify the details or requirements for JSON String values, other than such strings must consist of Unicode code points, nor does it specify how errors should be handled.  While JSONKit makes an effort (subject to the reasonable caveats above regarding Unicode) to preserve the parsed JSON String exactly, it can not guarantee that [`NSString`][NSString] will preserve the exact Unicode semantics of the original JSON String.
+    
+    JSONKit does not perform any form of Unicode Normalization on the parsed JSON Strings, but can not make any guarantees that the [`NSString`][NSString] class will not perform Unicode Normalization on the parsed JSON String used to instantiate the [`NSString`][NSString] object.  The [`NSString`][NSString] class may place additional restrictions or otherwise transform the JSON String in such a way so that the JSON String is not bijective with the instantiated [`NSString`][NSString] object.  In other words, JSONKit can not guarantee that when you round trip a JSON String to a [`NSString`][NSString] and then back to a JSON String that the two JSON Strings will be exactly the same, even though in practice they are.  For clarity, "exactly" in this case means bit for bit identical.  JSONKit can not even guarantee that the two JSON Strings will be [Unicode equivalent][Unicode_equivalence], even though in practice they will be and would be the most likely cause for the two round tripped JSON Strings to no longer be bit for bit identical.
+    
+*   JSONKit maps `true` and `false` to the [`CFBoolean`][CFBoolean] values [`kCFBooleanTrue`][kCFBooleanTrue] and [`kCFBooleanFalse`][kCFBooleanFalse], respectively.  Conceptually, [`CFBoolean`][CFBoolean] values can be thought of, and treated as, [`NSNumber`][NSNumber] class objects.  The benefit to using [`CFBoolean`][CFBoolean] is that `true` and `false` JSON values can be round trip deserialized and serialized without conversion or promotion to a [`NSNumber`][NSNumber] with a value of `0` or `1`.
+
+*   The [JSON specification][RFC 4627] does not specify the details or requirements for JSON Number values, nor does it specify how errors due to conversion should be handled.  In general, JSONKit will not accept JSON that contains JSON Number values that it can not convert with out error or loss of precision.
+
+    For non-floating-point numbers (i.e., JSON Number values that do not include a `.` or `e|E`), JSONKit uses a 64-bit C primitive type internally, regardless of whether the target architecture is 32-bit or 64-bit.  For unsigned values (i.e., those that do not begin with a `-`), this allows for values up to <code>2<sup>64</sup>-1</code> and up to <code>-2<sup>63</sup></code>   for negative values.  As a special case, the JSON Number `-0` is treated as a floating-point number since the underlying floating-point primitive type is capable of representing a negative zero, whereas the underlying twos-complement non-floating-point primitive type can not.  JSON that contains Number values that exceed these limits will fail to parse and optionally return a [`NSError`][NSError] object. The functions [`strtoll()`][strtoll] and [`strtoull()`][strtoull] are used to perform the conversions.
+
+    The C `double` primitive type, or [IEEE 754 Double 64-bit floating-point][Double Precision], is used to represent floating-point JSON Number values.  JSON that contains floating-point Number values that can not be represented as a `double` (i.e., due to over or underflow) will fail to parse and optionally return a [`NSError`][NSError] object.  The function [`strtod()`][strtod] is used to perform the conversion.  Note that the JSON standard does not allow for infinities or `NaN` (Not a Number).  The conversion and manipulation of [floating-point values is non-trivial](http://www.validlab.com/goldberg/paper.pdf).  Unfortunately, [RFC 4627][] is silent on how such details should be handled.  You should not depend on or expect that when a floating-point value is round tripped that it will have the same textual representation or even compare equal.  This is true even when JSONKit is used as both the parser and creator of the JSON, let alone when transferring JSON between different systems and implementations.
+    
+*   For JSON Objects (or [`NSDictionary`][NSDictionary] in JSONKit nomenclature), [RFC 4627][] says `The names within an object SHOULD be unique` (note: `name` is a `key` in JSONKit nomenclature). At this time the JSONKit behavior is `undefined` for JSON that contains names within an object that are not unique.  However, JSONKit currently tries to follow a "the last key / value pair parsed is the one chosen" policy. This behavior is not finalized and should not be depended on.
+    
+    The previously covered limitations regarding JSON Strings have important consequences for JSON Objects since JSON Strings are used as the `key`.  The [JSON specification][RFC 4627] does not specify the details or requirements for JSON Strings used as `keys` in JSON Objects, specifically what it means for two `keys` to compare equal.  Unfortunately, because [RFC 4627][] states `JSON text SHALL be encoded in Unicode.`, this means that one must use the [Unicode Standard][] to interpret the JSON, and the [Unicode Standard][] allows for strings that are encoded with different Unicode Code Points to "compare equal".  JSONKit uses [`NSString`][NSString] exclusively to manage the parsed JSON Strings.  Because [`NSString`][NSString] uses [Unicode][Unicode Standard] as its basis, there exists the possibility that [`NSString`][NSString] may subtly and silently convert the Unicode Code Points contained in the original JSON String in to a [Unicode equivalent][Unicode_equivalence] string.  Due to this, the JSONKit behavior for JSON Strings used as `keys` in JSON Objects that may be [Unicode equivalent][Unicode_equivalence] but not binary equivalent is `undefined`.
+    
+    **See also:**<br /> 
+    &nbsp;&nbsp;&nbsp;&nbsp;[W3C - Requirements for String Identity Matching and String Indexing](http://www.w3.org/TR/charreq/#sec2)
+
+### Objective-C To JSON Primitive Mapping Details
+
+*    When serializing, the top level container, and all of its children, are required to be *strictly* [invariant][wiki_invariant] during enumeration.  This property is used to make certain optimizations, such as if a particular object has already been serialized, the result of the previous serialized `UTF8` string can be reused (i.e., the `UTF8` string of the previous serialization can simply be copied instead of performing all the serialization work again).  While this is probably only of interest to those who are doing extraordinarily unusual things with the run-time or custom classes inheriting from the classes that JSONKit will serialize (i.e, a custom object whose value mutates each time it receives a message requesting its value for serialization), it also covers the case where any of the objects to be serialized are mutated during enumeration (i.e., mutated by another thread).  The number of times JSONKit will request an objects value is non-deterministic, from a minimum of once up to the number of times it appears in the serialized JSON&ndash; therefore an object MUST NOT depend on receiving a message requesting its value each time it appears in the serialized output. The behavior is `undefined` if these requirements are violated.
+
+*   The objects to be serialized MUST be acyclic.  If the objects to be serialized contain circular references the behavior is `undefined`.  For example,
+
+    ```objective-c
+    [arrayOne addObject:arrayTwo];
+    [arrayTwo addObject:arrayOne];
+    id json = [arrayOne JSONString];
+    ```
+    
+    &hellip; will result in `undefined` behavior.
+
+*   The contents of [`NSString`][NSString] objects are encoded as `UTF8` and added to the serialized JSON.  JSONKit assumes that [`NSString`][NSString] produces well-formed `UTF8` Unicode and does no additional validation of the conversion.  When `JKSerializeOptionEscapeUnicode` is enabled, JSONKit will encode Unicode code points that can be encoded as a single `UTF16` code unit as <code>\u<i>XXXX</i></code>, and will encode Unicode code points that require `UTF16` surrogate pairs as <code>\u<i>high</i>\u<i>low</i></code>.  While JSONKit makes every effort to serialize the contents of a [`NSString`][NSString] object exactly, modulo any [RFC 4627][] requirements, the [`NSString`][NSString] class uses the [Unicode Standard][] as its basis for representing strings.  You should be aware that the [Unicode Standard][] defines [string equivalence][Unicode_equivalence] in a such a way that two strings that compare equal are not required to be bit for bit identical.  Therefore there exists the possibility that [`NSString`][NSString] may mutate a string in such a way that it is [Unicode equivalent][Unicode_equivalence], but not bit for bit identical with the original string. 
+
+*   The [`NSDictionary`][NSDictionary] class allows for any object, which can be of any class, to be used as a `key`.  JSON, however, only permits Strings to be used as `keys`. Therefore JSONKit will fail with an error if it encounters a [`NSDictionary`][NSDictionary] that contains keys that are not [`NSString`][NSString] objects during serialization.  More specifically, the keys must return `YES` when sent [`-isKindOfClass:[NSString class]`][-isKindOfClass:]. 
+
+*   JSONKit will fail with an error if it encounters an object that is not a [`NSNull`][NSNull], [`NSNumber`][NSNumber], [`NSString`][NSString], [`NSArray`][NSArray], or [`NSDictionary`][NSDictionary] class object during serialization.  More specifically, JSONKit will fail with an error if it encounters an object where [`-isKindOfClass:`][-isKindOfClass:] returns `NO` for all of the previously mentioned classes.
+
+*   JSON does not allow for Numbers that are <code>&plusmn;Infinity</code> or <code>&plusmn;NaN</code>.  Therefore JSONKit will fail with an error if it encounters a [`NSNumber`][NSNumber] that contains such a value during serialization.
+
+*   Objects created with [`[NSNumber numberWithBool:YES]`][NSNumber_numberWithBool] and [`[NSNumber numberWithBool:NO]`][NSNumber_numberWithBool] will be mapped to the JSON values of `true` and `false`, respectively.  More specifically, an object must have pointer equality with [`kCFBooleanTrue`][kCFBooleanTrue] or [`kCFBooleanFalse`][kCFBooleanFalse] (i.e., `if((id)object == (id)kCFBooleanTrue)`) in order to be mapped to the JSON values `true` and `false`.
+
+*   [`NSNumber`][NSNumber] objects that are not booleans (as defined above) are sent [`-objCType`][-objCType] to determine what type of C primitive type they represent.  Those that respond with a type from the set `cislq` are treated as `long long`, those that respond with a type from the set `CISLQB` are treated as `unsigned long long`, and those that respond with a type from the set `fd` are treated as `double`.  [`NSNumber`][NSNumber] objects that respond with a type not in the set of types mentioned will cause JSONKit to fail with an error.
+    
+    More specifically, [`CFNumberGetValue(object, kCFNumberLongLongType, &longLong)`][CFNumberGetValue] is used to retrieve the value of both the signed and unsigned integer values, and the type reported by [`-objCType`][-objCType] is used to determine whether the result is signed or unsigned.  For floating-point values, [`CFNumberGetValue`][CFNumberGetValue] is used to retrieve the value using [`kCFNumberDoubleType`][kCFNumberDoubleType] for the type argument.
+    
+    Floating-point numbers are converted to their decimal representation using the [`printf`][printf] format conversion specifier `%.17g`.  Theoretically this allows up to a `float`, or [IEEE 754 Single 32-bit floating-point][Single Precision], worth of precision to be represented.  This means that for practical purposes, `double` values are converted to `float` values with the associated loss of precision.  The [RFC 4627][] standard is silent on how floating-point numbers should be dealt with and the author has found that real world JSON implementations vary wildly in how they handle this issue.  Furthermore, the `%g` format conversion specifier may convert floating-point values that can be exactly represented as an integer to a textual representation that does not include a `.` or `e`&ndash; essentially silently promoting a floating-point value to an integer value (i.e, `5.0` becomes `5`).  Because of these and many other issues surrounding the conversion and manipulation of floating-point values, you should not expect or depend on floating point values to maintain their full precision, or when round tripped, to compare equal.
+
+
+### Reporting Bugs
+
+Please use the [github.com JSONKit Issue Tracker](https://github.com/johnezang/JSONKit/issues) to report bugs.
+
+The author requests that you do not file a bug report with JSONKit regarding problems reported by the `clang` static analyzer unless you first manually verify that it is an actual, bona-fide problem with JSONKit and, if appropriate, is not "legal" C code as defined by the C99 language specification.  If the `clang` static analyzer is reporting a problem with JSONKit that is not an actual, bona-fide problem and is perfectly legal code as defined by the C99 language specification, then the appropriate place to file a bug report or complaint is with the developers of the `clang` static analyzer.
+
+### Important Details
+
+*   JSONKit is not designed to be used with the Mac OS X Garbage Collection.  The behavior of JSONKit when compiled with `-fobjc-gc` is `undefined`.  It is extremely unlikely that Mac OS X Garbage Collection will ever be supported.
+
+*   JSONKit is not designed to be used with [Objective-C Automatic Reference Counting (ARC)][ARC].  The behavior of JSONKit when compiled with `-fobjc-arc` is `undefined`.  The behavior of JSONKit compiled without [ARC][] mixed with code that has been compiled with [ARC][] is normatively `undefined` since at this time no analysis has been done to understand if this configuration is safe to use.  At this time, there are no plans to support [ARC][] in JSONKit.  Although tenative, it is extremely unlikely that [ARC][] will ever be supported, for many of the same reasons that Mac OS X Garbage Collection is not supported.
+
+*   The JSON to be parsed by JSONKit MUST be encoded as Unicode.  In the unlikely event you end up with JSON that is not encoded as Unicode, you must first convert the JSON to Unicode, preferably as `UTF8`.  One way to accomplish this is with the [`NSString`][NSString] methods [`-initWithBytes:length:encoding:`][NSString_initWithBytes] and [`-initWithData:encoding:`][NSString_initWithData].
+
+*   Internally, the low level parsing engine uses `UTF8` exclusively.  The `JSONDecoder` method `-objectWithData:` takes a [`NSData`][NSData] object as its argument and it is assumed that the raw bytes contained in the [`NSData`][NSData] is `UTF8` encoded, otherwise the behavior is `undefined`.
+
+*   It is not safe to use the same instantiated `JSONDecoder` object from multiple threads at the same time.  If you wish to share a `JSONDecoder` between threads, you are responsible for adding mutex barriers to ensure that only one thread is decoding JSON using the shared `JSONDecoder` object at a time.
+
+### Tips for speed
+
+*   Enable the `NS_BLOCK_ASSERTIONS` pre-processor flag.  JSONKit makes heavy use of [`NSCParameterAssert()`][NSCParameterAssert] internally to ensure that various arguments, variables, and other state contains only legal and expected values.  If an assertion check fails it causes a run time exception that will normally cause a program to terminate.  These checks and assertions come with a price: they take time to execute and do not contribute to the work being performed.  It is perfectly safe to enable `NS_BLOCK_ASSERTIONS` as JSONKit always performs checks that are required for correct operation.  The checks performed with [`NSCParameterAssert()`][NSCParameterAssert] are completely optional and are meant to be used in "debug" builds where extra integrity checks are usually desired.  While your mileage may vary, the author has found that adding `-DNS_BLOCK_ASSERTIONS` to an `-O2` optimization setting can generally result in an approximate <span style="white-space: nowrap;">7-12%</span> increase in performance.
+
+*   Since the very low level parsing engine works exclusively with `UTF8` byte streams, anything that is not already encoded as `UTF8` must first be converted to `UTF8`.  While JSONKit provides additions to the [`NSString`][NSString] class which allows you to conveniently convert JSON contained in a [`NSString`][NSString], this convenience does come with a price. JSONKit must allocate an autoreleased [`NSMutableData`][NSMutableData] large enough to hold the strings `UTF8` conversion and then convert the string to `UTF8` before it can begin parsing.  This takes both memory and time.  Once the parsing has finished, JSONKit sets the autoreleased [`NSMutableData`][NSMutableData] length to `0`, which allows the [`NSMutableData`][NSMutableData] to release the memory.  This helps to minimize the amount of memory that is in use but unavailable  until the autorelease pool pops. Therefore, if speed and memory usage are a priority, you should avoid using the [`NSString`][NSString] convenience methods if possible.
+
+*   If you are receiving JSON data from a web server, and you are able to determine that the raw bytes returned by the web server is JSON encoded as `UTF8`, you should use the `JSONDecoder` method `-objectWithUTF8String:length:` which immediately begins parsing the pointers bytes. In practice, every JSONKit method that converts JSON to an Objective-C object eventually calls this method to perform the conversion.
+
+*   If you are using one of the various ways provided by the `NSURL` family of classes to receive JSON results from a web server, which typically return the results in the form of a [`NSData`][NSData] object, and you are able to determine that the raw bytes contained in the [`NSData`][NSData] are encoded as `UTF8`, then you should use either the `JSONDecoder` method `objectWithData:` or the [`NSData`][NSData] method `-objectFromJSONData`.  If are going to be converting a lot of JSON, the better choice is to instantiate a `JSONDecoder` object once and use the same instantiated object to perform all your conversions.  This has two benefits:
+    1. The [`NSData`][NSData] method `-objectFromJSONData` creates an autoreleased `JSONDecoder` object to perform the one time conversion.  By instantiating a `JSONDecoder` object once and using the `objectWithData:` method repeatedly, you can avoid this overhead.
+    2. The instantiated object cache from the previous JSON conversion is reused.  This can result in both better performance and a reduction in memory usage if the JSON your are converting is very similar.  A typical example might be if you are converting JSON at periodic intervals that consists of real time status updates.
+
+*   On average, the <code>JSONData&hellip;</code> methods are nearly four times faster than the <code>JSONString&hellip;</code> methods when serializing a [`NSDictionary`][NSDictionary] or [`NSArray`][NSArray] to JSON.  The difference in speed is due entirely to the instantiation overhead of [`NSString`][NSString].
+
+*   If at all possible, use [`NSData`][NSData] instead of [`NSString`][NSString] methods when processing JSON.  This avoids the sometimes significant conversion overhead that [`NSString`][NSString] performs in order to provide an object oriented interface for its contents.   For many uses, using [`NSString`][NSString] is not needed and results in wasted effort&ndash;  for example, using JSONKit to serialize a [`NSDictionary`][NSDictionary] or [`NSArray`][NSArray] to a [`NSString`][NSString].  This [`NSString`][NSString] is then passed to a method that sends the JSON to a web server, and this invariably requires converting the [`NSString`][NSString] to [`NSData`][NSData] before it can be sent.  In this case, serializing the collection object directly to [`NSData`][NSData] would avoid the unnecessary conversions to and from a [`NSString`][NSString] object.
+
+### Parsing Interface
+
+#### JSONDecoder Interface
+
+The <code>objectWith&hellip;</code> methods return immutable collection objects and their respective <code>mutableObjectWith&hellip;</code> methods return mutable collection objects.
+
+**Note:** The bytes contained in a [`NSData`][NSData] object ***MUST*** be `UTF8` encoded.
+
+**Important:** Methods will raise [`NSInvalidArgumentException`][NSInvalidArgumentException] if `parseOptionFlags` is not valid.  
+**Important:** `objectWithUTF8String:` and `mutableObjectWithUTF8String:` will raise [`NSInvalidArgumentException`][NSInvalidArgumentException] if `string` is `NULL`.  
+**Important:** `objectWithData:` and `mutableObjectWithData:` will raise [`NSInvalidArgumentException`][NSInvalidArgumentException] if `jsonData` is `NULL`.
+
+```objective-c
++ (id)decoder;
++ (id)decoderWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)initWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+
+- (void)clearCache;
+
+- (id)objectWithUTF8String:(const unsigned char *)string length:(size_t)length;
+- (id)objectWithUTF8String:(const unsigned char *)string length:(size_t)length error:(NSError **)error;
+- (id)mutableObjectWithUTF8String:(const unsigned char *)string length:(size_t)length;
+- (id)mutableObjectWithUTF8String:(const unsigned char *)string length:(size_t)length error:(NSError **)error;
+
+- (id)objectWithData:(NSData *)jsonData;
+- (id)objectWithData:(NSData *)jsonData error:(NSError **)error;
+- (id)mutableObjectWithData:(NSData *)jsonData;
+- (id)mutableObjectWithData:(NSData *)jsonData error:(NSError **)error;
+```
+
+#### NSString Interface
+
+```objective-c
+- (id)objectFromJSONString;
+- (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)objectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+- (id)mutableObjectFromJSONString;
+- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)mutableObjectFromJSONStringWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+```
+
+#### NSData Interface
+
+```objective-c
+- (id)objectFromJSONData;
+- (id)objectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)objectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+- (id)mutableObjectFromJSONData;
+- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags;
+- (id)mutableObjectFromJSONDataWithParseOptions:(JKParseOptionFlags)parseOptionFlags error:(NSError **)error;
+```
+
+#### JKParseOptionFlags
+
+<table>
+  <tr><th>Parsing Option</th><th>Description</th></tr>
+  <tr><td valign="top"><code>JKParseOptionNone</code></td><td>This is the default if no other other parse option flags are specified, and the option used when a convenience method does not provide an argument for explicitly specifying the parse options to use.  Synonymous with <code>JKParseOptionStrict</code>.</td></tr>
+  <tr><td valign="top"><code>JKParseOptionStrict</code></td><td>The JSON will be parsed in strict accordance with the <a href="http://tools.ietf.org/html/rfc4627">RFC 4627</a> specification.</td></tr>
+  <tr><td valign="top"><code>JKParseOptionComments</code></td><td>Allow C style <code>//</code> and <code>/* &hellip; */</code> comments in JSON.  This is a fairly common extension to JSON, but JSON that contains C style comments is not strictly conforming JSON.</td></tr>
+  <tr><td valign="top"><code>JKParseOptionUnicodeNewlines</code></td><td>Allow Unicode recommended <code>(?:\r\n|[\n\v\f\r\x85\p{Zl}\p{Zp}])</code> newlines in JSON.  The <a href="http://tools.ietf.org/html/rfc4627">JSON specification</a> only allows the newline characters <code>\r</code> and <code>\n</code>, but this option allows JSON that contains the <a href="http://en.wikipedia.org/wiki/Newline#Unicode">Unicode recommended newline characters</a> to be parsed.  JSON that contains these additional newline characters is not strictly conforming JSON.</td></tr>
+  <tr><td valign="top"><code>JKParseOptionLooseUnicode</code></td><td>Normally the decoder will stop with an error at any malformed Unicode. This option allows JSON with malformed Unicode to be parsed without reporting an error. Any malformed Unicode is replaced with <code>\uFFFD</code>, or <code>REPLACEMENT CHARACTER</code>, as specified in <a href="http://www.unicode.org/versions/Unicode6.0.0/ch03.pdf">The Unicode 6.0 standard, Chapter 3</a>, section 3.9 <em>Unicode Encoding Forms</em>.</td></tr>
+  <tr><td valign="top"><code>JKParseOptionPermitTextAfterValidJSON</code></td><td>Normally, <code>non-white-space</code> that follows the JSON is interpreted as a parsing failure. This option allows for any trailing <code>non-white-space</code> to be ignored and not cause a parsing error.</td></tr>
+</table>
+
+### Serializing Interface
+
+The serializing interface includes [`NSString`][NSString] convenience methods for those that need to serialize a single [`NSString`][NSString].  For those that need this functionality, the [`NSString`][NSString] additions are much more convenient than having to wrap a single [`NSString`][NSString] in a [`NSArray`][NSArray], which then requires stripping the unneeded `[`&hellip;`]` characters from the serialized JSON result.  When serializing a single [`NSString`][NSString], you can control whether or not the serialized JSON result is surrounded by quotation marks using the `includeQuotes:` argument:
+
+Example       | Result            | Argument
+--------------|-------------------|--------------------
+`a "test"...` | `"a \"test\"..."` | `includeQuotes:YES`
+`a "test"...` | `a \"test\"...`   | `includeQuotes:NO`
+
+**Note:** The [`NSString`][NSString] methods that do not include a `includeQuotes:` argument behave as if invoked with `includeQuotes:YES`.  
+**Note:** The bytes contained in the returned [`NSData`][NSData] object are `UTF8` encoded.
+
+#### NSArray and NSDictionary Interface
+
+```objective-c
+- (NSData *)JSONData;
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
+- (NSString *)JSONString;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions error:(NSError **)error;
+```
+
+
+#### NSString Interface
+
+```objective-c
+- (NSData *)JSONData;
+- (NSData *)JSONDataWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError **)error;
+- (NSString *)JSONString;
+- (NSString *)JSONStringWithOptions:(JKSerializeOptionFlags)serializeOptions includeQuotes:(BOOL)includeQuotes error:(NSError **)error;
+```
+
+#### JKSerializeOptionFlags
+
+<table>
+  <tr><th>Serializing Option</th><th>Description</th></tr>
+  <tr><td valign="top"><code>JKSerializeOptionNone</code></td><td>This is the default if no other other serialize option flags are specified, and the option used when a convenience method does not provide an argument for explicitly specifying the serialize options to use.</td></tr>
+  <tr><td valign="top"><code>JKSerializeOptionPretty</code></td><td>Normally the serialized JSON does not include any unnecessary <code>white-space</code>.  While this form is the most compact, the lack of any <code>white-space</code> means that it's something only another JSON parser could love.  Enabling this option causes JSONKit to add additional <code>white-space</code> that makes it easier for people to read.  Other than the extra <code>white-space</code>, the serialized JSON is identical to the JSON that would have been produced had this option not been enabled.</td></tr>
+  <tr><td valign="top"><code>JKSerializeOptionEscapeUnicode</code></td><td>When JSONKit encounters Unicode characters in <a href="http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/index.html"><code>NSString</code></a> objects, the default behavior is to encode those Unicode characters as <code>UTF8</code>.  This option causes JSONKit to encode those characters as <code>\u<i>XXXX</i></code>.  For example,<br/><code>["w&isin;L&#10234;y(&#8739;y&#8739;&le;&#8739;w&#8739;)"]</code><br/>becomes:<br/><code>["w\u2208L\u27fa\u2203y(\u2223y\u2223\u2264\u2223w\u2223)"]</code></td></tr>
+  <tr><td valign="top"><code>JKSerializeOptionEscapeForwardSlashes</code></td><td>According to the <a href="http://tools.ietf.org/html/rfc4627">JSON specification</a>, the <code>/</code> (<code>U+002F</code>) character may be backslash escaped (i.e., <code>\/</code>), but it is not required.  The default behavior of JSONKit is to <b><i>not</i></b> backslash escape the <code>/</code> character.  Unfortunately, it was found some real world implementations of the <a href="http://weblogs.asp.net/bleroy/archive/2008/01/18/dates-and-json.aspx">ASP.NET Date Format</a> require the date to be <i>strictly</i> encoded as <code>\/Date(...)\/</code>, and the only way to achieve this is through the use of <code>JKSerializeOptionEscapeForwardSlashes</code>.  See <a href="https://github.com/johnezang/JSONKit/issues/21">github issue #21</a> for more information.</td></tr>
+</table>
+
+[JSON]: http://www.json.org/
+[RFC 4627]: http://tools.ietf.org/html/rfc4627
+[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[Single Precision]: http://en.wikipedia.org/wiki/Single_precision_floating-point_format
+[Double Precision]: http://en.wikipedia.org/wiki/Double_precision_floating-point_format
+[wiki_invariant]: http://en.wikipedia.org/wiki/Invariant_(computer_science)
+[ARC]: http://clang.llvm.org/docs/AutomaticReferenceCounting.html
+[CFBoolean]: http://developer.apple.com/mac/library/documentation/CoreFoundation/Reference/CFBooleanRef/index.html
+[kCFBooleanTrue]: http://developer.apple.com/mac/library/documentation/CoreFoundation/Reference/CFBooleanRef/Reference/reference.html#//apple_ref/doc/c_ref/kCFBooleanTrue
+[kCFBooleanFalse]: http://developer.apple.com/mac/library/documentation/CoreFoundation/Reference/CFBooleanRef/Reference/reference.html#//apple_ref/doc/c_ref/kCFBooleanFalse
+[kCFNumberDoubleType]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFNumberRef/Reference/reference.html#//apple_ref/doc/c_ref/kCFNumberDoubleType
+[CFNumberGetValue]: http://developer.apple.com/library/mac/documentation/CoreFoundation/Reference/CFNumberRef/Reference/reference.html#//apple_ref/c/func/CFNumberGetValue
+[Unicode Standard]: http://www.unicode.org/versions/Unicode6.0.0/
+[Unicode Standard - Conformance]: http://www.unicode.org/versions/Unicode6.0.0/ch03.pdf
+[Unicode_equivalence]: http://en.wikipedia.org/wiki/Unicode_equivalence
+[UnicodeNewline]: http://en.wikipedia.org/wiki/Newline#Unicode
+[Unicode_UTR36]: http://www.unicode.org/reports/tr36/
+[Unicode_UTR36_NonVisualSecurity]: http://www.unicode.org/reports/tr36/#Canonical_Represenation
+[Unicode_UTR36_Deleting]: http://www.unicode.org/reports/tr36/#Deletion_of_Noncharacters
+[Unicode_Security_FAQ]: http://www.unicode.org/faq/security.html
+[NSNull]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSNull_Class/index.html
+[NSNumber]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSNumber_Class/index.html
+[NSNumber_numberWithBool]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSNumber_Class/Reference/Reference.html#//apple_ref/occ/clm/NSNumber/numberWithBool:
+[NSString]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/index.html
+[NSString_initWithBytes]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/Reference/NSString.html#//apple_ref/occ/instm/NSString/initWithBytes:length:encoding:
+[NSString_initWithData]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/Reference/NSString.html#//apple_ref/occ/instm/NSString/initWithData:encoding:
+[NSString_UTF8String]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSString_Class/Reference/NSString.html#//apple_ref/occ/instm/NSString/UTF8String
+[NSArray]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSArray_Class/index.html
+[NSDictionary]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSDictionary_Class/index.html
+[NSError]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSError_Class/index.html
+[NSData]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/index.html
+[NSMutableData]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Classes/NSMutableData_Class/index.html
+[NSInvalidArgumentException]: http://developer.apple.com/mac/library/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Constants/Reference/reference.html#//apple_ref/doc/c_ref/NSInvalidArgumentException
+[CFString]: http://developer.apple.com/library/mac/#documentation/CoreFoundation/Reference/CFStringRef/Reference/reference.html
+[NSCParameterAssert]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Functions/Reference/reference.html#//apple_ref/c/macro/NSCParameterAssert
+[-mutableCopy]: http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Classes/NSObject_Class/Reference/Reference.html%23//apple_ref/occ/instm/NSObject/mutableCopy
+[-isKindOfClass:]: http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/Foundation/Protocols/NSObject_Protocol/Reference/NSObject.html%23//apple_ref/occ/intfm/NSObject/isKindOfClass:
+[-objCType]: http://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSNumber_Class/Reference/Reference.html#//apple_ref/occ/instm/NSNumber/objCType
+[strtoll]: http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/strtoll.3.html
+[strtod]: http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/strtod.3.html
+[strtoull]: http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/strtoull.3.html
+[getrusage]: http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man2/getrusage.2.html
+[printf]: http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man3/printf.3.html

--- a/MapView/Map/RMInteractiveSource.h
+++ b/MapView/Map/RMInteractiveSource.h
@@ -1,0 +1,111 @@
+//
+//  RMInteractiveSource.h
+//
+//  Created by Justin Miller on 6/22/11.
+//  Copyright 2011, Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the name of Development Seed, Inc., nor the names of its
+//        contributors may be used to endorse or promote products derived from
+//        this software without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//  Example usage at: https://github.com/mapbox/MBTiles-Interactivity-Example
+//
+
+#import "RMMBTilesTileSource.h"
+#import "RMTileStreamSource.h"
+#import "RMCachedTileSource.h"
+
+@class RMMapView;
+
+/**
+ * Interactivity currently supports two types of output: 'teaser'
+ * and 'full'. Ideal for master/detail interfaces or for showing
+ * a MapKit-style detail-toggling point callout. 
+ */
+typedef enum {
+    RMInteractiveSourceOutputTypeTeaser = 0,
+    RMInteractiveSourceOutputTypeFull   = 1,
+} RMInteractiveSourceOutputType;
+
+@protocol RMInteractiveSource
+
+@required
+
+/**
+ * Query if a tile source supports interactivity features.
+ */
+- (BOOL)supportsInteractivity;
+
+/**
+ * Get the raw interactivity dictionary for a given point.
+ */
+- (NSDictionary *)interactivityDictionaryForPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+
+/**
+ * Get the raw interactivity formatter JavaScript for a source.
+ */
+- (NSString *)interactivityFormatterJavascript;
+
+/**
+ * Get the HTML-formatted output for a given point. This is probably 
+ * what you want most of the time after determining that a source 
+ * supports interactivity.
+ */
+- (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+
+@end
+
+#pragma mark -
+
+@interface RMMBTilesTileSource (RMInteractiveSource) <RMInteractiveSource>
+
+- (BOOL)supportsInteractivity;
+- (NSDictionary *)interactivityDictionaryForPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+- (NSString *)interactivityFormatterJavascript;
+- (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+
+@end
+
+#pragma mark -
+
+@interface RMTileStreamSource (RMInteractiveSource) <RMInteractiveSource>
+
+- (BOOL)supportsInteractivity;
+- (NSDictionary *)interactivityDictionaryForPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+- (NSString *)interactivityFormatterJavascript;
+- (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+
+@end
+
+#pragma mark -
+
+@interface RMCachedTileSource (RMInteractiveSource) <RMInteractiveSource>
+
+- (BOOL)supportsInteractivity;
+- (NSDictionary *)interactivityDictionaryForPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+- (NSString *)interactivityFormatterJavascript;
+- (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+
+@end

--- a/MapView/Map/RMInteractiveSource.m
+++ b/MapView/Map/RMInteractiveSource.m
@@ -256,7 +256,8 @@ RMTilePoint RMInteractiveSourceNormalizedTilePointForMapView(CGPoint point, RMMa
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"MBTiles: %@, zooms %i-%i, %@", 
+    return [NSString stringWithFormat:@"%@: %@, zooms %i-%i, %@", 
+               [self class],
                [self shortName], 
                (int)[self minZoom], 
                (int)[self maxZoom], 
@@ -371,7 +372,8 @@ RMTilePoint RMInteractiveSourceNormalizedTilePointForMapView(CGPoint point, RMMa
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"TileStream: %@, zooms %i-%i, %@", 
+    return [NSString stringWithFormat:@"%@: %@, zooms %i-%i, %@", 
+               [self class],
                [self shortName], 
                (int)[self minZoom], 
                (int)[self maxZoom], 
@@ -464,6 +466,16 @@ RMTilePoint RMInteractiveSourceNormalizedTilePointForMapView(CGPoint point, RMMa
 #pragma mark Cached Source Interactivity
 
 @implementation RMCachedTileSource (RMInteractiveSource)
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"%@: %@, zooms %i-%i, %@", 
+               [tileSource class],
+               [self shortName], 
+               (int)[self minZoom], 
+               (int)[self maxZoom], 
+               ([self supportsInteractivity] ? @"supports interactivity" : @"no interactivity")];
+}
 
 - (BOOL)supportsInteractivity
 {

--- a/MapView/Map/RMInteractiveSource.m
+++ b/MapView/Map/RMInteractiveSource.m
@@ -1,0 +1,508 @@
+//
+//  RMInteractiveSource.m
+//
+//  Created by Justin Miller on 6/22/11.
+//  Copyright 2011, Development Seed, Inc.
+//  All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//  
+//      * Redistributions of source code must retain the above copyright
+//        notice, this list of conditions and the following disclaimer.
+//  
+//      * Redistributions in binary form must reproduce the above copyright
+//        notice, this list of conditions and the following disclaimer in the
+//        documentation and/or other materials provided with the distribution.
+//  
+//      * Neither the name of Development Seed, Inc., nor the names of its
+//        contributors may be used to endorse or promote products derived from
+//        this software without specific prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "RMInteractiveSource.h"
+
+#import "RMMapView.h"
+#import "RMMapContents.h"
+#import "RMLatLong.h"
+
+#import "FMDatabase.h"
+
+#import "JSONKit.h"
+
+#import <QuartzCore/QuartzCore.h>
+#import <UIKit/UIKit.h>
+
+#include "zlib.h"
+
+#pragma mark Private Utilities
+
+RMTilePoint RMInteractiveSourceNormalizedTilePointForMapView(CGPoint point, RMMapView *mapView);
+
+RMTilePoint RMInteractiveSourceNormalizedTilePointForMapView(CGPoint point, RMMapView *mapView)
+{
+    // determine renderer scroll layer sub-layer touched
+    //
+    CALayer *rendererLayer = [mapView.contents.renderer valueForKey:@"layer"];
+    CALayer *tileLayer     = [rendererLayer hitTest:point];
+    
+    // convert touch to sub-layer
+    //
+    CGPoint layerPoint = [tileLayer convertPoint:point fromLayer:rendererLayer];
+    
+    // normalize tile touch to 256px
+    //
+    // TODO: assert that tile side length is 256
+    //
+    float normalizedX = (layerPoint.x / tileLayer.bounds.size.width)  * 256;
+    float normalizedY = (layerPoint.y / tileLayer.bounds.size.height) * 256;
+
+    // determine lat & lon of touch
+    //
+    RMLatLong touchLocation = [mapView.contents pixelToLatLong:point];
+    
+    // use lat & lon to determine TMS tile (per http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+    //
+    int tileZoom = (int)(roundf(mapView.contents.zoom));
+    
+    int tileX = (int)(floor((touchLocation.longitude + 180.0) / 360.0 * pow(2.0, tileZoom)));
+    int tileY = (int)(floor((1.0 - log(tan(touchLocation.latitude * M_PI / 180.0) + 1.0 / \
+                                       cos(touchLocation.latitude * M_PI / 180.0)) / M_PI) / 2.0 * pow(2.0, tileZoom)));
+    
+    tileY = pow(2.0, tileZoom) - tileY - 1.0;
+    
+    RMTile tile = {
+        .zoom = tileZoom,
+        .x    = tileX,
+        .y    = tileY,
+    };
+    
+    RMTilePoint tilePoint;
+    
+    tilePoint.tile   = tile;
+    tilePoint.offset = CGPointMake(normalizedX, normalizedY);
+    
+    return tilePoint;
+}
+
+@interface RMInteractiveSource : NSObject
+
++ (NSString *)keyNameForPoint:(CGPoint)point inGrid:(NSDictionary *)grid;
++ (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)type forPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+
+@end
+
+@implementation RMInteractiveSource
+
++ (NSString *)keyNameForPoint:(CGPoint)point inGrid:(NSDictionary *)grid
+{
+    NSString *keyName = nil;
+    
+    if ([grid objectForKey:@"grid"] && [grid objectForKey:@"keys"])
+    {
+        NSArray *rows = [grid objectForKey:@"grid"];
+        NSArray *keys = [grid objectForKey:@"keys"];
+        
+        if (rows && [rows isKindOfClass:[NSArray class]] && keys && [keys isKindOfClass:[NSArray class]])
+        {
+            if ([rows count] > 0)
+            {
+                // get grid coordinates per https://github.com/mapbox/mbtiles-spec/blob/master/1.1/utfgrid.md
+                //
+                int factor = 256 / [rows count];
+                int row    = point.y / factor;
+                int col    = point.x / factor;
+                
+                if (row < [rows count])
+                {
+                    NSString *line = [rows objectAtIndex:row];
+                    
+                    if (col < [line length])
+                    {
+                        unichar theChar = [line characterAtIndex:col];
+                        unsigned short decoded = theChar;
+                        
+                        if (decoded >= 93)
+                            decoded--;
+                        
+                        if (decoded >=35)
+                            decoded--;
+                        
+                        decoded = decoded - 32;
+                        
+                        if (decoded < [keys count])
+                            keyName = [keys objectAtIndex:decoded];
+                    }
+                }
+            }
+        }
+    }
+    
+    return keyName;
+}
+
++ (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView
+{
+    NSString *formattedOutput = nil;
+    
+    id <RMTileSource>source = mapView.contents.tileSource;
+    
+    NSDictionary *interactivityDictionary = [(id <RMInteractiveSource>)source interactivityDictionaryForPoint:point inMapView:mapView];
+    NSString     *formatterJavascript     = [(id <RMInteractiveSource>)source interactivityFormatterJavascript];
+    
+    if (interactivityDictionary && formatterJavascript)
+    {
+        UIWebView *formatter = [[[UIWebView alloc] initWithFrame:CGRectZero] autorelease];
+        
+        NSString  *keyJSON = [interactivityDictionary objectForKey:@"keyJSON"];
+        
+        [formatter stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"var data   = %@;", keyJSON]];
+        [formatter stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"var format = %@;", formatterJavascript]];
+        
+        NSString *format;
+        
+        switch (outputType)
+        {
+            case RMInteractiveSourceOutputTypeTeaser:
+                format = @"teaser";
+                break;
+                
+            case RMInteractiveSourceOutputTypeFull:
+            default:
+                format = @"full";
+                break;
+        }
+        
+        [formatter stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"var options = { format: '%@' }", format]];
+        
+        formattedOutput = [formatter stringByEvaluatingJavaScriptFromString:@"format(options, data);"];
+    }
+    
+    return formattedOutput;
+}
+
+@end
+
+@interface NSData (RMInteractiveSource)
+
+- (NSData *)gzipInflate;
+
+@end
+
+@implementation NSData (RMInteractiveSource)
+
+- (NSData *)gzipInflate
+{
+    // from http://cocoadev.com/index.pl?NSDataCategory
+    //
+    if ([self length] == 0) return self;
+    
+    unsigned full_length = [self length];
+    unsigned half_length = [self length] / 2;
+    
+    NSMutableData *decompressed = [NSMutableData dataWithLength: full_length + half_length];
+    BOOL done = NO;
+    int status;
+    
+    z_stream strm;
+    strm.next_in = (Bytef *)[self bytes];
+    strm.avail_in = [self length];
+    strm.total_out = 0;
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    
+    if (inflateInit2(&strm, (15+32)) != Z_OK) return nil;
+    while (!done)
+    {
+        // Make sure we have enough room and reset the lengths.
+        if (strm.total_out >= [decompressed length])
+            [decompressed increaseLengthBy: half_length];
+        strm.next_out = [decompressed mutableBytes] + strm.total_out;
+        strm.avail_out = [decompressed length] - strm.total_out;
+        
+        // Inflate another chunk.
+        status = inflate (&strm, Z_SYNC_FLUSH);
+        if (status == Z_STREAM_END) done = YES;
+        else if (status != Z_OK) break;
+    }
+    if (inflateEnd (&strm) != Z_OK) return nil;
+    
+    // Set real length.
+    if (done)
+    {
+        [decompressed setLength: strm.total_out];
+        return [NSData dataWithData: decompressed];
+    }
+    else return nil;
+}
+
+@end
+
+#pragma mark -
+#pragma mark MBTiles Interactivity
+
+@implementation RMMBTilesTileSource (RMInteractiveSource)
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"MBTiles: %@, zooms %i-%i, %@", 
+               [self shortName], 
+               (int)[self minZoom], 
+               (int)[self maxZoom], 
+               ([self supportsInteractivity] ? @"supports interactivity" : @"no interactivity")];
+}
+
+- (BOOL)supportsInteractivity
+{
+    return ([self interactivityFormatterJavascript] && [[self interactivityFormatterJavascript] length]);
+}
+
+- (NSDictionary *)interactivityDictionaryForPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+{
+    RMTilePoint tilePoint = RMInteractiveSourceNormalizedTilePointForMapView(point, mapView);
+    
+    FMResultSet *results = [db executeQuery:@"select grid from grids where zoom_level = ? and tile_column = ? and tile_row = ?", 
+                               [NSNumber numberWithShort:tilePoint.tile.zoom], 
+                               [NSNumber numberWithUnsignedInt:tilePoint.tile.x], 
+                               [NSNumber numberWithUnsignedInt:tilePoint.tile.y]];
+    
+    if ([db hadError])
+        return nil;
+    
+    [results next];
+    
+    NSData *gridData = nil;
+    
+    if ([results hasAnotherRow])
+        gridData = [results dataForColumnIndex:0];
+    
+    [results close];
+    
+    if (gridData)
+    {
+        NSData *inflatedData = [gridData gzipInflate];
+        NSString *gridString = [[[NSString alloc] initWithData:inflatedData encoding:NSUTF8StringEncoding] autorelease];
+        
+        id grid = [gridString objectFromJSONString];
+        
+        if (grid && [grid isKindOfClass:[NSDictionary class]])
+        {
+            NSString *keyName = [RMInteractiveSource keyNameForPoint:tilePoint.offset inGrid:grid];
+            
+            if (keyName)
+            {
+                // get JSON for this grid point
+                //
+                results = [db executeQuery:@"select key_json from grid_data where zoom_level = ? and tile_column = ? and tile_row = ? and key_name = ?", 
+                              [NSNumber numberWithShort:tilePoint.tile.zoom],
+                              [NSNumber numberWithShort:tilePoint.tile.x],
+                              [NSNumber numberWithShort:tilePoint.tile.y],
+                              keyName];
+                
+                if ([db hadError])
+                    return nil;
+                
+                [results next];
+                
+                NSString *jsonString = nil;
+                
+                if ([results hasAnotherRow])
+                    jsonString = [results stringForColumn:@"key_json"];
+                
+                [results close];
+                
+                if (jsonString)
+                {
+                    return [NSDictionary dictionaryWithObjectsAndKeys:keyName,    @"keyName",
+                                                                      jsonString, @"keyJSON", 
+                                                                      nil];
+                }
+            }
+        }
+    }
+    
+    return nil;    
+}
+
+- (NSString *)interactivityFormatterJavascript
+{
+    FMResultSet *results = [db executeQuery:@"select value from metadata where name = 'formatter'"];
+    
+    if ([db hadError])
+        return nil;
+    
+    [results next];
+    
+    NSString *js = nil;
+    
+    if ([results hasAnotherRow])
+        js = [results stringForColumn:@"value"];
+    
+    [results close];
+    
+    return js;
+}
+
+- (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView
+{
+    if ([self supportsInteractivity])
+        return [RMInteractiveSource formattedOutputOfType:outputType forPoint:point inMapView:mapView];
+    
+    return nil;
+}
+
+@end
+
+#pragma mark -
+#pragma mark TileStream Interactivity
+
+@implementation RMTileStreamSource (RMInteractiveSource)
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"TileStream: %@, zooms %i-%i, %@", 
+               [self shortName], 
+               (int)[self minZoom], 
+               (int)[self maxZoom], 
+               ([self supportsInteractivity] ? @"supports interactivity" : @"no interactivity")];
+}
+
+- (BOOL)supportsInteractivity
+{
+    return ([self interactivityFormatterJavascript] && [[self interactivityFormatterJavascript] length]);
+}
+
+- (NSDictionary *)interactivityDictionaryForPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+{
+    if ([self.infoDictionary objectForKey:@"gridURL"])
+    {
+        RMTilePoint tilePoint = RMInteractiveSourceNormalizedTilePointForMapView(point, mapView);
+        
+        NSInteger zoom = tilePoint.tile.zoom;
+        NSInteger x    = tilePoint.tile.x;
+        NSInteger y    = tilePoint.tile.y;
+        
+        NSString *gridURLString = [self.infoDictionary objectForKey:@"gridURL"];
+        
+        gridURLString = [gridURLString stringByReplacingOccurrencesOfString:@"{z}" withString:[[NSNumber numberWithInteger:zoom] stringValue]];
+        gridURLString = [gridURLString stringByReplacingOccurrencesOfString:@"{x}" withString:[[NSNumber numberWithInteger:x]    stringValue]];
+        gridURLString = [gridURLString stringByReplacingOccurrencesOfString:@"{y}" withString:[[NSNumber numberWithInteger:y]    stringValue]];
+
+        // ensure JSONP format
+        //
+        if ( ! [gridURLString hasSuffix:@"?callback=grid"])
+            gridURLString = [gridURLString stringByAppendingString:@"?callback=grid"];
+
+        // get the data for this tile
+        //
+        NSData *gridData = [NSData dataWithContentsOfURL:[NSURL URLWithString:gridURLString]];
+        
+        if (gridData)
+        {
+            NSMutableString *gridString = [[[NSMutableString alloc] initWithData:gridData encoding:NSUTF8StringEncoding] autorelease];
+            
+            // remove JSONP 'grid(' and ');' bits
+            //
+            if ([gridString hasPrefix:@"grid("])
+            {
+                [gridString replaceCharactersInRange:NSMakeRange(0, 5)                       withString:@""];
+                [gridString replaceCharactersInRange:NSMakeRange([gridString length] - 2, 2) withString:@""];
+            }
+            
+            id grid = [gridString objectFromJSONString];
+            
+            if (grid && [grid isKindOfClass:[NSDictionary class]])
+            {
+                NSString *keyName = [RMInteractiveSource keyNameForPoint:tilePoint.offset inGrid:grid];
+                
+                if (keyName)
+                {
+                    NSDictionary *data = [grid objectForKey:@"data"];
+                    
+                    if (data)                    
+                        return [NSDictionary dictionaryWithObjectsAndKeys:keyName,                                  @"keyName",
+                                                                          [[data objectForKey:keyName] JSONString], @"keyJSON",
+                                                                          nil];
+                }
+            }
+        }
+    }
+    
+    return nil;    
+}
+
+- (NSString *)interactivityFormatterJavascript
+{
+    if ([self.infoDictionary objectForKey:@"formatter"])
+        return [self.infoDictionary objectForKey:@"formatter"];
+    
+    return nil;
+}
+
+- (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView
+{
+    if ([self supportsInteractivity])
+        return [RMInteractiveSource formattedOutputOfType:outputType forPoint:point inMapView:mapView];
+    
+    return nil;
+}
+
+@end
+
+#pragma mark -
+#pragma mark Cached Source Interactivity
+
+@implementation RMCachedTileSource (RMInteractiveSource)
+
+- (BOOL)supportsInteractivity
+{
+    /**
+     * Cached tile sources have an internal, underlying `tileSource` that
+     * points to the original source. Check if that is a supported type
+     * and if so, if it supports interactivity.
+     */
+
+    NSArray *supportedClasses = [NSArray arrayWithObjects:[RMMBTilesTileSource class], [RMTileStreamSource class], nil];
+    
+    if ([supportedClasses containsObject:[tileSource class]] && [tileSource conformsToProtocol:@protocol(RMInteractiveSource)])
+        return [(id <RMInteractiveSource>)tileSource supportsInteractivity];
+    
+    return NO;
+}
+
+- (NSDictionary *)interactivityDictionaryForPoint:(CGPoint)point inMapView:(RMMapView *)mapView;
+{
+    if ([self supportsInteractivity])
+        return [(id <RMInteractiveSource>)tileSource interactivityDictionaryForPoint:point inMapView:mapView];
+    
+    return nil;
+}
+
+- (NSString *)interactivityFormatterJavascript
+{
+    if ([self supportsInteractivity])
+        return [(id <RMInteractiveSource>)tileSource interactivityFormatterJavascript];
+    
+    return nil;
+}
+
+- (NSString *)formattedOutputOfType:(RMInteractiveSourceOutputType)outputType forPoint:(CGPoint)point inMapView:(RMMapView *)mapView
+{
+    if ([self supportsInteractivity])
+        return [RMInteractiveSource formattedOutputOfType:outputType forPoint:point inMapView:mapView];
+    
+    return nil;
+}
+
+@end

--- a/MapView/Map/RMInteractiveSource.m
+++ b/MapView/Map/RMInteractiveSource.m
@@ -469,7 +469,7 @@ RMTilePoint RMInteractiveSourceNormalizedTilePointForMapView(CGPoint point, RMMa
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"%@: %@, zooms %i-%i, %@", 
+    return [NSString stringWithFormat:@"%@ (cached): %@, zooms %i-%i, %@", 
                [tileSource class],
                [self shortName], 
                (int)[self minZoom], 

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -212,6 +212,10 @@
 		DDA3E85713B00D9E004D861C /* RMMapQuestOSMSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */; };
 		DDCD58D31406F8A400F59E0D /* RMTileStreamSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */; };
 		DDCD58D41406F8A400F59E0D /* RMTileStreamSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */; };
+		DDF0B75E1411985900ED0DF4 /* RMInteractiveSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF0B75C1411985900ED0DF4 /* RMInteractiveSource.h */; };
+		DDF0B75F1411985900ED0DF4 /* RMInteractiveSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF0B75D1411985900ED0DF4 /* RMInteractiveSource.m */; };
+		DDF0B7631411992500ED0DF4 /* JSONKit.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF0B7611411992500ED0DF4 /* JSONKit.h */; };
+		DDF0B7641411992500ED0DF4 /* JSONKit.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF0B7621411992500ED0DF4 /* JSONKit.m */; };
 		F5C12D2A0F8A86CA00A894D2 /* RMGeoHash.h in Headers */ = {isa = PBXBuildFile; fileRef = F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */; };
 		F5C12D2B0F8A86CA00A894D2 /* RMGeoHash.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */; };
 /* End PBXBuildFile section */
@@ -405,6 +409,10 @@
 		DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMMapQuestOSMSource.m; sourceTree = "<group>"; };
 		DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileStreamSource.h; sourceTree = "<group>"; };
 		DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMTileStreamSource.m; sourceTree = "<group>"; };
+		DDF0B75C1411985900ED0DF4 /* RMInteractiveSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMInteractiveSource.h; sourceTree = "<group>"; };
+		DDF0B75D1411985900ED0DF4 /* RMInteractiveSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMInteractiveSource.m; sourceTree = "<group>"; };
+		DDF0B7611411992500ED0DF4 /* JSONKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSONKit.h; path = JSONKit/JSONKit.h; sourceTree = "<group>"; };
+		DDF0B7621411992500ED0DF4 /* JSONKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JSONKit.m; path = JSONKit/JSONKit.m; sourceTree = "<group>"; };
 		F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMGeoHash.h; sourceTree = "<group>"; };
 		F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMGeoHash.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -706,6 +714,7 @@
 				DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */,
 				DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */,
 				DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */,
+				DDF0B760141198B500ED0DF4 /* Interactivity */,
 			);
 			name = "Tile Source";
 			sourceTree = "<group>";
@@ -833,6 +842,17 @@
 			name = "Coordinate Systems";
 			sourceTree = "<group>";
 		};
+		DDF0B760141198B500ED0DF4 /* Interactivity */ = {
+			isa = PBXGroup;
+			children = (
+				DDF0B75C1411985900ED0DF4 /* RMInteractiveSource.h */,
+				DDF0B75D1411985900ED0DF4 /* RMInteractiveSource.m */,
+				DDF0B7611411992500ED0DF4 /* JSONKit.h */,
+				DDF0B7621411992500ED0DF4 /* JSONKit.m */,
+			);
+			name = Interactivity;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -898,6 +918,8 @@
 				175701DE1323C2E900A5D314 /* NSUserDefaults+RouteMe.h in Headers */,
 				DDA3E85613B00D9E004D861C /* RMMapQuestOSMSource.h in Headers */,
 				DDCD58D31406F8A400F59E0D /* RMTileStreamSource.h in Headers */,
+				DDF0B75E1411985900ED0DF4 /* RMInteractiveSource.h in Headers */,
+				DDF0B7631411992500ED0DF4 /* JSONKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1201,6 +1223,8 @@
 				175701DF1323C2E900A5D314 /* NSUserDefaults+RouteMe.m in Sources */,
 				DDA3E85713B00D9E004D861C /* RMMapQuestOSMSource.m in Sources */,
 				DDCD58D41406F8A400F59E0D /* RMTileStreamSource.m in Sources */,
+				DDF0B75F1411985900ED0DF4 /* RMInteractiveSource.m in Sources */,
+				DDF0B7641411992500ED0DF4 /* JSONKit.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This commit adds embedded interactivity for MBTiles and TileStream tile sources. 

Interactivity is a way to store pixel-specific contextual data about map tiles in a way that's space-efficient and easy to retrieve on demand. 

Here is a sample iPhone project using this branch of route-me to demonstrate: 

https://github.com/mapbox/MBTiles-Interactivity-Example

Basically, you tap a country on the map and get its name and a flag image _for every pixel on the globe_. 

[This file](https://github.com/mapbox/MBTiles-Interactivity-Example/blob/master/MBTiles%20Interactivity%20Example/InteractivityViewController.m) in the demo project shows the basic usage. 

Besides the `RMInteractivity.h` & `RMInteractivity.m` that contain the routines, this brings in [JSONKit](https://github.com/johnezang/JSONKit) and requires linking against `zlib`, since the interactivity is based on compressed JSON-encoded data. 

I've written this in a way that allows anyone to use route-me as normal, including the MBTiles & TileStream tile sources, but only to incur the interactivity overhead if they want it by pulling in a single header. 
