### PR TITLE
linked to new TileStream API docs & sample code

### DIFF
--- a/MapView/Map/RMTileStreamSource.h
+++ b/MapView/Map/RMTileStreamSource.h
@@ -30,7 +30,10 @@
 //  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-//  http://mapbox.com/tilestream
+//  http://mapbox.com/hosting/
+//  http://mapbox.com/hosting/hosting-api/
+//
+//  Example usage at https://github.com/mapbox/tilestream-ios-example
 //
 //  This class supports both the paid, hosted version of TileStream, as well as the 
 //  open source, self-hosted version. 

--- a/MapView/Map/RMTileStreamSource.h
+++ b/MapView/Map/RMTileStreamSource.h
@@ -30,8 +30,7 @@
 //  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-//  http://mapbox.com/hosting/
-//  http://mapbox.com/hosting/hosting-api/
+//  http://mapbox.com/hosting/api/
 //
 //  Example usage at https://github.com/mapbox/tilestream-ios-example
 //


### PR DESCRIPTION
Just some doc & sample code linking in the `RMTileStreamSource` header. This applies to both the hosted version and the open source version. 
