### PR TITLE
legend support for MBTiles & TileStream sources

### DIFF
--- a/MapView/Map/RMMBTilesTileSource.h
+++ b/MapView/Map/RMMBTilesTileSource.h
@@ -74,6 +74,7 @@ typedef enum {
 - (void)setMaxZoom:(NSUInteger)aMaxZoom;
 - (RMSphericalTrapezium)latitudeLongitudeBoundingBox;
 - (BOOL)coversFullWorld;
+- (NSString *)legend;
 - (RMMBTilesLayerType)layerType;
 - (void)didReceiveMemoryWarning;
 - (NSString *)uniqueTilecacheKey;

--- a/MapView/Map/RMMBTilesTileSource.m
+++ b/MapView/Map/RMMBTilesTileSource.m
@@ -249,6 +249,25 @@
     return ([type isEqualToString:@"overlay"] ? RMMBTilesLayerTypeOverlay : RMMBTilesLayerTypeBaselayer);
 }
 
+- (NSString *)legend
+{
+    FMResultSet *results = [db executeQuery:@"select value from metadata where name = 'legend'"];
+    
+    if ([db hadError])
+        return nil;
+    
+    [results next];
+    
+    NSString *legend = nil;
+    
+    if ([results hasAnotherRow])
+        legend = [results stringForColumn:@"value"];
+    
+    [results close];
+    
+    return legend;
+}
+
 - (void)didReceiveMemoryWarning
 {
     NSLog(@"*** didReceiveMemoryWarning in %@", [self class]);

--- a/MapView/Map/RMTileStreamSource.h
+++ b/MapView/Map/RMTileStreamSource.h
@@ -58,6 +58,7 @@
 //
 
 #import "RMAbstractMercatorWebSource.h"
+#import "RMCachedTileSource.h"
 
 #define kTileStreamDefaultTileSize 256
 #define kTileStreamDefaultMinTileZoom 0
@@ -77,9 +78,18 @@ typedef enum {
 
 - (id)initWithInfo:(NSDictionary *)info;
 - (id)initWithReferenceURL:(NSURL *)referenceURL;
+- (NSString *)legend;
 - (RMTileStreamLayerType)layerType;
 - (BOOL)coversFullWorld;
 
 @property (nonatomic, readonly, retain) NSDictionary *infoDictionary;
+
+@end
+
+#pragma mark -
+
+@interface RMCachedTileSource (RMTileStreamSourceExtensions)
+
+- (NSString *)legend;
 
 @end

--- a/MapView/Map/RMTileStreamSource.m
+++ b/MapView/Map/RMTileStreamSource.m
@@ -33,7 +33,7 @@
 
 #import "RMTileStreamSource.h"
 
-@interface RMTileStreamSource (RMTileStreamSourcePrivate)
+@interface RMTileStreamSource ()
 
 @property (nonatomic, retain) NSDictionary *infoDictionary;
 
@@ -154,9 +154,28 @@
 	return [self shortAttribution];
 }
 
+- (NSString *)legend
+{
+    return [self.infoDictionary objectForKey:@"legend"];
+}
+
 - (RMTileStreamLayerType)layerType
 {
     return ([[self.infoDictionary objectForKey:@"type"] isEqualToString:@"overlay"] ? RMTileStreamLayerTypeOverlay : RMTileStreamLayerTypeBaselayer);
+}
+
+@end
+
+#pragma mark -
+
+@implementation RMCachedTileSource (RMTileStreamSourceExtensions)
+
+- (NSString *)legend
+{
+    if ([tileSource isKindOfClass:[RMTileStreamSource class]])
+        return [(RMTileStreamSource *)tileSource legend];
+    
+    return nil;
 }
 
 @end


### PR DESCRIPTION
This adds legend support to MBTiles & TileStream tile sources. Legends are just chunks of HTML that can be displayed on a map layer, like in this web map: http://tiles.mapbox.com/mapbox/map/map_1313537819317

This also adds a method to `RMCachedTileSource` via category so that cached TileStream sources can return legends, too. 
