### PR TITLE
Use NSOperation and NSOperationQueue to download image tiles from the web in concurent threads.

### DIFF
--- a/MapView/Map/RMDatabaseCache.m
+++ b/MapView/Map/RMDatabaseCache.m
@@ -127,8 +127,9 @@
 				[dao purgeTiles: MAX(minimalPurge, 1+tilesInDb-capacity)];
 			}
 		}
-	
-		[dao addData:data LastUsed:[image lastUsedTime] ForTile:RMTileKey([image tile])];
+        NSDate *lastUsedTime = [[image lastUsedTime] retain];
+		[dao addData:data LastUsed: lastUsedTime ForTile:RMTileKey([image tile])];
+        [lastUsedTime release]; lastUsedTime = nil;
 	}
 	
 	[[NSNotificationCenter defaultCenter] removeObserver:self

--- a/MapView/Map/RMURLConnectionOperation.h
+++ b/MapView/Map/RMURLConnectionOperation.h
@@ -1,7 +1,7 @@
 //
-//  RMWebTileImage.h
+//  RMURLConnectionOperation.h
 //
-// Copyright (c) 2008-2009, Route-Me Contributors
+// Copyright (c) 2008-2011, Route-Me Contributors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -25,40 +25,17 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+
 #import <Foundation/Foundation.h>
-#import "RMTileImage.h"
 
-#import "RMURLConnectionOperation.h"
-
-static const NSUInteger kWebTileRetries = 30;
-static const NSUInteger kMaxConcurrentConnections = 5;
-
-extern NSString *RMWebTileImageErrorDomain;
-
-extern NSString *RMWebTileImageHTTPResponseCodeKey;
-enum {
-    RMWebTileImageErrorUnexpectedHTTPResponse,
-    RMWebTileImageErrorZeroLengthResponse,
-    RMWebTileImageErrorNotFoundResponse
-};
-
-extern NSString *RMWebTileImageNotificationErrorKey;
-
-
-
-/// RMTileImage subclass: a tile image loaded from a URL.
-@interface RMWebTileImage : RMTileImage {
-    NSUInteger retries;
-    NSError *lastError;
-
-	NSURL *url;
-    RMURLConnectionOperation *connectionOp;
-
-	NSMutableData *data;
+@interface RMURLConnectionOperation : NSOperation {
+    id                      _delegate;
+    NSURLConnection         *_connection;
+    NSURLRequest            *_request;
+    BOOL                    _isRunning;
 }
 
-- (id) initWithTile: (RMTile)tile FromURL:(NSString*)url;
-- (void) requestTile;
-- (void) startLoading:(NSTimer *)timer;
+-(id)initWithRequest:(NSURLRequest *)request delegate:(id)delegate;
+-(void)stop;
 
 @end

--- a/MapView/Map/RMURLConnectionOperation.m
+++ b/MapView/Map/RMURLConnectionOperation.m
@@ -44,17 +44,21 @@
     {
         return;
     }
-    _connection = [[NSURLConnection alloc] initWithRequest:_request delegate:_delegate startImmediately:NO];
-    [_request release];
-    [_connection start];
+    _connection = [[NSURLConnection alloc] initWithRequest:_request delegate:_delegate startImmediately:YES];
+    [_request release];_request = nil;
     while (_isRunning && ![self isCancelled] && [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]]);
     [_connection cancel];
     [_connection release];
     _connection = nil; 
 }
 
--(void)stop{
+-(void)stop {
     _isRunning = NO;
+}
+
+-(void)dealloc {
+    [_request release];
+    [super dealloc];
 }
 
 @end

--- a/MapView/Map/RMURLConnectionOperation.m
+++ b/MapView/Map/RMURLConnectionOperation.m
@@ -1,5 +1,5 @@
 //
-//  RMWebTileImage.h
+//  RMURLConnectionOperation.m
 //
 // Copyright (c) 2008-2009, Route-Me Contributors
 // All rights reserved.
@@ -25,40 +25,36 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#import <Foundation/Foundation.h>
-#import "RMTileImage.h"
-
 #import "RMURLConnectionOperation.h"
 
-static const NSUInteger kWebTileRetries = 30;
-static const NSUInteger kMaxConcurrentConnections = 5;
+@implementation RMURLConnectionOperation
 
-extern NSString *RMWebTileImageErrorDomain;
-
-extern NSString *RMWebTileImageHTTPResponseCodeKey;
-enum {
-    RMWebTileImageErrorUnexpectedHTTPResponse,
-    RMWebTileImageErrorZeroLengthResponse,
-    RMWebTileImageErrorNotFoundResponse
-};
-
-extern NSString *RMWebTileImageNotificationErrorKey;
-
-
-
-/// RMTileImage subclass: a tile image loaded from a URL.
-@interface RMWebTileImage : RMTileImage {
-    NSUInteger retries;
-    NSError *lastError;
-
-	NSURL *url;
-    RMURLConnectionOperation *connectionOp;
-
-	NSMutableData *data;
+-(id)initWithRequest:(NSURLRequest *)request delegate:(id)delegate {
+    if((self = [super init]))
+    {
+        _delegate = delegate;
+        _request = [request retain];
+        _isRunning = YES;
+    }
+    return self;
 }
 
-- (id) initWithTile: (RMTile)tile FromURL:(NSString*)url;
-- (void) requestTile;
-- (void) startLoading:(NSTimer *)timer;
+-(void)main {
+    if ([self isCancelled] || !_isRunning)
+    {
+        return;
+    }
+    _connection = [[NSURLConnection alloc] initWithRequest:_request delegate:_delegate startImmediately:NO];
+    [_request release];
+    [_connection start];
+    while (_isRunning && ![self isCancelled] && [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]]);
+    [_connection cancel];
+    [_connection release];
+    _connection = nil; 
+}
+
+-(void)stop{
+    _isRunning = NO;
+}
 
 @end

--- a/MapView/MapView.xcodeproj/project.pbxproj
+++ b/MapView/MapView.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		DDA3E85713B00D9E004D861C /* RMMapQuestOSMSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */; };
 		DDCD58D31406F8A400F59E0D /* RMTileStreamSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */; };
 		DDCD58D41406F8A400F59E0D /* RMTileStreamSource.m in Sources */ = {isa = PBXBuildFile; fileRef = DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */; };
+		F56554F8146E002B00623AC9 /* RMURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = F56554F6146E002B00623AC9 /* RMURLConnectionOperation.h */; };
+		F56554F9146E002B00623AC9 /* RMURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = F56554F7146E002B00623AC9 /* RMURLConnectionOperation.m */; };
 		F5C12D2A0F8A86CA00A894D2 /* RMGeoHash.h in Headers */ = {isa = PBXBuildFile; fileRef = F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */; };
 		F5C12D2B0F8A86CA00A894D2 /* RMGeoHash.m in Sources */ = {isa = PBXBuildFile; fileRef = F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */; };
 /* End PBXBuildFile section */
@@ -405,6 +407,8 @@
 		DDA3E85513B00D9E004D861C /* RMMapQuestOSMSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMMapQuestOSMSource.m; sourceTree = "<group>"; };
 		DDCD58D11406F8A300F59E0D /* RMTileStreamSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMTileStreamSource.h; sourceTree = "<group>"; };
 		DDCD58D21406F8A300F59E0D /* RMTileStreamSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMTileStreamSource.m; sourceTree = "<group>"; };
+		F56554F6146E002B00623AC9 /* RMURLConnectionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMURLConnectionOperation.h; sourceTree = "<group>"; };
+		F56554F7146E002B00623AC9 /* RMURLConnectionOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMURLConnectionOperation.m; sourceTree = "<group>"; };
 		F5C12D280F8A86CA00A894D2 /* RMGeoHash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMGeoHash.h; sourceTree = "<group>"; };
 		F5C12D290F8A86CA00A894D2 /* RMGeoHash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMGeoHash.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -628,6 +632,8 @@
 		B83E64CE0E80E73F001663B6 /* Tile Images */ = {
 			isa = PBXGroup;
 			children = (
+				F56554F6146E002B00623AC9 /* RMURLConnectionOperation.h */,
+				F56554F7146E002B00623AC9 /* RMURLConnectionOperation.m */,
 				B83E64D80E80E73F001663B6 /* RMTileImage.h */,
 				B83E64D90E80E73F001663B6 /* RMTileImage.m */,
 				D1437B30122869E400888DAE /* RMDBTileImage.m */,
@@ -898,6 +904,7 @@
 				175701DE1323C2E900A5D314 /* NSUserDefaults+RouteMe.h in Headers */,
 				DDA3E85613B00D9E004D861C /* RMMapQuestOSMSource.h in Headers */,
 				DDCD58D31406F8A400F59E0D /* RMTileStreamSource.h in Headers */,
+				F56554F8146E002B00623AC9 /* RMURLConnectionOperation.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1201,6 +1208,7 @@
 				175701DF1323C2E900A5D314 /* NSUserDefaults+RouteMe.m in Sources */,
 				DDA3E85713B00D9E004D861C /* RMMapQuestOSMSource.m in Sources */,
 				DDCD58D41406F8A400F59E0D /* RMTileStreamSource.m in Sources */,
+				F56554F9146E002B00623AC9 /* RMURLConnectionOperation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
The use of NSOperation/NSOperationQueue to download image tiles from web helps to unload work from the main thread and permit a smoother map scrolling, particularly in iOS5. 
