### PR TITLE
Adds tapOnLabelForMarker:onMap:onLayer: method to RMMapViewDelegate protocol.

### DIFF
--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -139,6 +139,7 @@ typedef struct {
 	BOOL _delegateHasSingleTapOnMap;
 	BOOL _delegateHasTapOnMarker;
 	BOOL _delegateHasTapOnLabelForMarker;
+	BOOL _delegateHasTapOnLabelForMarkerOnLayer;
 	BOOL _delegateHasAfterMapTouch;
 	BOOL _delegateHasShouldDragMarker;
 	BOOL _delegateHasDidDragMarker;

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -193,6 +193,7 @@
 	
 	_delegateHasTapOnMarker = [(NSObject*) delegate respondsToSelector:@selector(tapOnMarker:onMap:)];
 	_delegateHasTapOnLabelForMarker = [(NSObject*) delegate respondsToSelector:@selector(tapOnLabelForMarker:onMap:)];
+	_delegateHasTapOnLabelForMarkerOnLayer = [(NSObject*) delegate respondsToSelector:@selector(tapOnLabelForMarker:onMap:onLayer:)];
 	
 	_delegateHasAfterMapTouch  = [(NSObject*) delegate respondsToSelector: @selector(afterMapTouch:)];
    
@@ -586,10 +587,16 @@
 					if (_delegateHasTapOnLabelForMarker) {
 						[delegate tapOnLabelForMarker:(RMMarker*)superlayer onMap:self];
 					}
+                    if (_delegateHasTapOnLabelForMarkerOnLayer) {
+                        [delegate tapOnLabelForMarker:(RMMarker*)superlayer onMap:self onLayer:hit];
+                    }
 				} else if ([superlayer superlayer] != nil && [[superlayer superlayer] isKindOfClass: [RMMarker class]]) {
                                         if (_delegateHasTapOnLabelForMarker) {
                                                 [delegate tapOnLabelForMarker:(RMMarker*)[superlayer superlayer] onMap:self];
                                         } 
+                    if (_delegateHasTapOnLabelForMarkerOnLayer) {
+                        [delegate tapOnLabelForMarker:(RMMarker*)[superlayer superlayer] onMap:self onLayer:hit];
+                    }
 				} else if (_delegateHasSingleTapOnMap) {
 					[delegate singleTapOnMap: self At: [touch locationInView:self]];
 				}

--- a/MapView/Map/RMMapViewDelegate.h
+++ b/MapView/Map/RMMapViewDelegate.h
@@ -57,6 +57,7 @@
 
 - (void) tapOnMarker: (RMMarker*) marker onMap: (RMMapView*) map;
 - (void) tapOnLabelForMarker: (RMMarker*) marker onMap: (RMMapView*) map;
+- (void) tapOnLabelForMarker: (RMMarker*) marker onMap: (RMMapView*) map onLayer:(CALayer *)layer;
 - (BOOL) mapView:(RMMapView *)map shouldDragMarker:(RMMarker *)marker withEvent:(UIEvent *)event;
 - (void) mapView:(RMMapView *)map didDragMarker:(RMMarker *)marker withEvent:(UIEvent *)event;
 


### PR DESCRIPTION
Adds tapOnLabelForMarker:onMap:onLayer: method to RMMapViewDelegate protocol.

This method allows the implementation of tappable buttons in markers label.

For instance, you can add a button layer with name @"NameOfYourButtonLayerHere" to a marker label and implement the method tapOnLabelForMarker:onMap:onLayer: for your RMMapViewDelegate as follows:
- (void) tapOnLabelForMarker:(RMMarker_)marker
                     onMap:(RMMapView_)map
                     onLayer:(CALayer *)layer
  {
  if (layer.name == @"NameOfYourButtonLayerHere") {
      //Code to serve button tap here
  }
  }

See also http://stackoverflow.com/questions/5967909/route-me-marker-label-with-uibuttontypedetaildisclosure-button-button-isnt-cl
