### PR TITLE
Fixing zooming issue when the user try to zoom in a mapview with constraining coordinates.

### DIFF
--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -349,7 +349,7 @@
 			zRect.size.height = screenBounds.size.height * metersPerPixel;
 			 
 			//can zoom only if within bounds
-			canZoom= !(zRect.origin.northing < SWconstraint.northing || zRect.origin.northing+zRect.size.height> NEconstraint.northing ||
+			canZoom= zoomDelta > 0 || !(zRect.origin.northing < SWconstraint.northing || zRect.origin.northing+zRect.size.height> NEconstraint.northing ||
 			  zRect.origin.easting < SWconstraint.easting || zRect.origin.easting+zRect.size.width > NEconstraint.easting);
 				
 		}


### PR DESCRIPTION
Here I allow the zoom if the user wanted to zoom in, as always the user
can zoom in as long as the map is already displayed on the screen.

When the map is bounded to certain coordinates, some time the map
cannot be zoomed in if the zooming is taking place beside the boarders.

Note that when the zoom is at its max, the zoom will take place inside
the tile image itself.
