### PR TITLE
Added check for invalid retrieved image data in RMWebTileImage

### DIFF
--- a/MapView/Map/RMTileImage.h
+++ b/MapView/Map/RMTileImage.h
@@ -75,7 +75,7 @@ typedef NSImage UIImage;
 
 - (void)cancelLoading;
 
-- (void)updateImageUsingData: (NSData*) data;
+- (BOOL)updateImageUsingData: (NSData*) data;
 - (void)updateImageUsingImage: (UIImage*) image;
 
 - (void)touch;

--- a/MapView/Map/RMTileImage.m
+++ b/MapView/Map/RMTileImage.m
@@ -128,12 +128,18 @@
 }
 
 
-- (void)updateImageUsingData: (NSData*) data
+- (BOOL)updateImageUsingData: (NSData*) data
 {
-       [self updateImageUsingImage:[UIImage imageWithData:data]];
+    UIImage *image = [UIImage imageWithData:data];
+    if ( !image ) {
+        return NO;
+    }
+       [self updateImageUsingImage:image];
 
        NSDictionary *d = [NSDictionary dictionaryWithObject:data forKey:@"data"];
        [[NSNotificationCenter defaultCenter] postNotificationName:RMMapImageLoadedNotification object:self userInfo:d];
+    
+    return YES;
 }
 
 - (void)updateImageUsingImage: (UIImage*) rawImage

--- a/MapView/Map/RMWebTileImage.m
+++ b/MapView/Map/RMWebTileImage.m
@@ -70,6 +70,8 @@ static NSOperationQueue *_queue = nil;
 {
 	[self cancelLoading];
 	
+    if ( lastError ) [lastError release]; lastError = nil;
+	
 	[data release];
 	data = nil;
 	
@@ -286,7 +288,15 @@ static NSOperationQueue *_queue = nil;
 	}
 	else
 	{
-		[self updateImageUsingData:data];
+		if ( ![self updateImageUsingData:data] ) {
+            if ( lastError ) [lastError release];
+            lastError = [[NSError errorWithDomain:RMWebTileImageErrorDomain 
+                                             code:RMWebTileImageErrorUnexpectedHTTPResponse
+                                         userInfo:[NSDictionary dictionaryWithObjectsAndKeys:
+                                                   NSLocalizedString(@"The server returned an invalid response", @""), NSLocalizedDescriptionKey, nil]] retain];
+            [self requestTile];
+            return;
+        }
 		
 		[data release];
 		data = nil;


### PR DESCRIPTION
This adds a check to see if a UIImage can be created from the retrieved data, when loading tiles. If not, the request is automatically retried, until out of retries.

This avoids problems with temporary server outages that redirect to an HTML error page, or when on funny networks that drop or mess with connections, like public WiFi that uses captured portals to redirect users to a login screen.
