### PR TITLE
Added ability to use custom screen scale when initialising view

### DIFF
--- a/MapView/Map/RMMapContents.h
+++ b/MapView/Map/RMMapContents.h
@@ -133,7 +133,7 @@ enum {
 
 @property (nonatomic, readwrite) float minZoom, maxZoom;
 
-@property (nonatomic, assign) float screenScale;
+@property (nonatomic, readonly) float screenScale;
 
 @property (readonly)  RMTileImageSet *imagesOnScreen;
 @property (readonly)  RMTileLoader *tileLoader;
@@ -161,8 +161,9 @@ enum {
 @property (readonly, assign) BOOL fullyLoaded;
 
 - (id)initWithView: (UIView*) view;
-- (id)initWithView: (UIView*) view
-		tilesource:(id<RMTileSource>)newTilesource;
+- (id)initWithView: (UIView*) view screenScale:(float)theScreenScale;
+- (id)initWithView: (UIView*) view tilesource:(id<RMTileSource>)newTilesource;
+- (id)initWithView: (UIView*) view tilesource:(id<RMTileSource>)newTilesource screenScale:(float)theScreenScale;
 /// designated initializer
 - (id)initWithView:(UIView*)view
 		tilesource:(id<RMTileSource>)tilesource
@@ -170,7 +171,8 @@ enum {
 		 zoomLevel:(float)initialZoomLevel
 	  maxZoomLevel:(float)maxZoomLevel
 	  minZoomLevel:(float)minZoomLevel
-   backgroundImage:(UIImage *)backgroundImage;
+   backgroundImage:(UIImage *)backgroundImage
+       screenScale:(float)theScreenScale;
 
 /// \deprecated subject to removal at any moment after 0.5 is released
 - (id) initForView: (UIView*) view;

--- a/MapView/Map/RMMapContents.m
+++ b/MapView/Map/RMMapContents.m
@@ -88,11 +88,33 @@
 	  			    zoomLevel:kDefaultInitialZoomLevel
 				 maxZoomLevel:kDefaultMaximumZoomLevel
 				 minZoomLevel:kDefaultMinimumZoomLevel
-			  backgroundImage:nil];
+			  backgroundImage:nil
+                  screenScale:0];
+}
+
+- (id)initWithView: (UIView*) view screenScale:(float)theScreenScale {
+    LogMethod();
+	CLLocationCoordinate2D here;
+	here.latitude = kDefaultInitialLatitude;
+	here.longitude = kDefaultInitialLongitude;
+	
+	return [self initWithView:view
+				   tilesource:[[RMOpenStreetMapSource alloc] init]
+				 centerLatLon:here
+	  			    zoomLevel:kDefaultInitialZoomLevel
+				 maxZoomLevel:kDefaultMaximumZoomLevel
+				 minZoomLevel:kDefaultMinimumZoomLevel
+			  backgroundImage:nil
+                  screenScale:theScreenScale];
 }
 
 - (id)initWithView: (UIView*) view
 		tilesource:(id<RMTileSource>)newTilesource
+{
+    return [self initWithView:view tilesource:newTilesource screenScale:0.0];
+}
+
+-(id)initWithView:(UIView *)view tilesource:(id<RMTileSource>)newTilesource screenScale:(float)theScreenScale
 {	
 	LogMethod();
 	CLLocationCoordinate2D here;
@@ -105,7 +127,8 @@
 					zoomLevel:kDefaultInitialZoomLevel
 				 maxZoomLevel:kDefaultMaximumZoomLevel
 				 minZoomLevel:kDefaultMinimumZoomLevel
-			  backgroundImage:nil];
+			  backgroundImage:nil
+                  screenScale:theScreenScale];
 }
 
 - (id)initWithView:(UIView*)newView
@@ -115,6 +138,7 @@
 	  maxZoomLevel:(float)maxZoomLevel
 	  minZoomLevel:(float)minZoomLevel
    backgroundImage:(UIImage *)backgroundImage
+       screenScale:(float)theScreenScale
 {
 	LogMethod();
 	if (![super init])
@@ -130,10 +154,11 @@
 	imagesOnScreen = nil;
 	tileLoader = nil;
     
-    screenScale = 1.0;
+    screenScale = (theScreenScale == 0.0 ? 1.0 : theScreenScale);
     if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)])
     {
-        screenScale = [[[UIScreen mainScreen] valueForKey:@"scale"] floatValue];
+        float realScreenScale = [[[UIScreen mainScreen] valueForKey:@"scale"] floatValue];
+        screenScale = (theScreenScale == 0.0 ? realScreenScale : MIN(theScreenScale, realScreenScale));
     }
 
 	boundingMask = RMMapMinWidthBound;

--- a/MapView/Map/RMMapView.h
+++ b/MapView/Map/RMMapView.h
@@ -126,6 +126,7 @@ typedef struct {
 	float decelerationFactor;
 	BOOL deceleration;
         CGFloat rotation;
+    float screenScale;
 	
 @private
    	BOOL _delegateHasBeforeMapMove;
@@ -172,6 +173,8 @@ typedef struct {
 
 @property (readonly) CGFloat rotation;
 
+- (id)initWithFrame:(CGRect)frame;
+- (id)initWithFrame:(CGRect)frame screenScale:(float)screenScale;
 - (id)initWithFrame:(CGRect)frame WithLocation:(CLLocationCoordinate2D)latlong;
 
 /// recenter the map on #latlong, expressed as CLLocationCoordinate2D (latitude/longitude)

--- a/MapView/Map/RMMapView.m
+++ b/MapView/Map/RMMapView.m
@@ -75,6 +75,8 @@
 	decelerationFactor = kDefaultDecelerationFactor;
 	deceleration = NO;
 	
+    screenScale = 0.0;
+    
 	//	[self recalculateImageSet];
 	
 	if (enableZoom || enableRotate)
@@ -89,9 +91,15 @@
 
 - (id)initWithFrame:(CGRect)frame
 {
+    return [self initWithFrame:frame screenScale:0.0];
+}
+
+- (id)initWithFrame:(CGRect)frame screenScale:(float)theScreenScale
+{
 	LogMethod();
 	if (self = [super initWithFrame:frame]) {
 		[self performInitialSetup];
+        screenScale = theScreenScale;
 	}
 	return self;
 }
@@ -114,7 +122,7 @@
 - (RMMapContents *)contents
 {
     if (!_contentsIsSet) {
-		RMMapContents *newContents = [[RMMapContents alloc] initWithView:self];
+		RMMapContents *newContents = [[RMMapContents alloc] initWithView:self screenScale:screenScale];
 		self.contents = newContents;
 		[newContents release];
 		_contentsIsSet = YES;


### PR DESCRIPTION
This allows the map to be created, passing in a screen scale argument, controlling whether tiles are displayed at retina resolution (which may cause text labels to be too small for some), or standard 1x resolution.
