### PR TITLE
only hyphenate various fields when necessary

### DIFF
--- a/MapView/Map/RMMBTilesTileSource.m
+++ b/MapView/Map/RMMBTilesTileSource.m
@@ -307,7 +307,7 @@
     
     [results close];
     
-    return [NSString stringWithFormat:@"%@ - %@", [self shortName], description];
+    return [NSString stringWithFormat:@"%@%@%@", [self shortName], ([[self shortName] length] && [description length] ? @" - " : @""), description];
 }
 
 - (NSString *)shortAttribution
@@ -328,7 +328,7 @@
 
 - (NSString *)longAttribution
 {
-    return [NSString stringWithFormat:@"%@ - %@", [self shortName], [self shortAttribution]];
+    return [NSString stringWithFormat:@"%@%@%@", [self shortName], ([[self shortName] length] && [[self shortAttribution] length] ? @" - " : @""), [self shortAttribution]];
 }
 
 - (void)removeAllCachedImages


### PR DESCRIPTION
Just a couple minor tweaks to the MBTiles backend for better formatting. Without this, if you're missing various metadata in a file, the formatting can come out weird. 
