### PR TITLE
Updated RMPath to add line cap/join and shadow options

### DIFF
--- a/MapView/Map/RMPath.h
+++ b/MapView/Map/RMPath.h
@@ -34,30 +34,7 @@
 @class RMMapContents;
 @class RMMapView;
 
-@interface RMPath : RMMapLayer <RMMovingMapLayer> {
-	RMProjectedPoint projectedLocation;
-	
-	UIColor *lineColor;
-	UIColor *fillColor;
-	float lineWidth;
-	BOOL scaleLineWidth;
-    
-    CGFloat *_lineDashLengths;
-    CGFloat *_scaledLineDashLengths;
-    size_t _lineDashCount;
-    CGFloat lineDashPhase;
-    BOOL scaleLineDash;
-    
-	BOOL enableDragging;
-	BOOL enableRotation;
-	
-    CGMutablePathRef path;
-    
-	RMMapContents *mapContents;
-    
-    CGRect originalContentsRect;
-    BOOL redrawPending;
-}
+@interface RMPath : RMMapLayer <RMMovingMapLayer> 
 
 - (id) initWithContents: (RMMapContents*)aContents;
 - (id) initForMap: (RMMapView*)map;
@@ -71,11 +48,16 @@
 - (void) addLineToLatLong: (RMLatLong) point;
 - (void) closePath;
 
+@property (nonatomic, assign) CGLineCap lineCap;
+@property (nonatomic, assign) CGLineJoin lineJoin;
 @property (nonatomic, assign) float lineWidth;
 @property (nonatomic, assign) BOOL	scaleLineWidth;
-@property (nonatomic, readwrite, assign) NSArray *lineDashLengths;
-@property CGFloat lineDashPhase;
-@property BOOL scaleLineDash;
+@property (nonatomic, assign) CGFloat shadowBlur;
+@property (nonatomic, assign) CGSize shadowOffset;
+@property (nonatomic, retain) UIColor *shadowColor;
+@property (nonatomic, assign) NSArray *lineDashLengths;
+@property (nonatomic, assign) CGFloat lineDashPhase;
+@property (nonatomic, assign) BOOL scaleLineDash;
 @property (nonatomic, assign) RMProjectedPoint projectedLocation;
 @property (assign) BOOL enableDragging;
 @property (assign) BOOL enableRotation;

--- a/samples/MapTestbed/Classes/MapTestbedAppDelegate.m
+++ b/samples/MapTestbed/Classes/MapTestbedAppDelegate.m
@@ -75,8 +75,10 @@
 	testPath = [[RMPath alloc] initWithContents:mapContents];
 	[testPath setLineColor:[UIColor greenColor]];
 	[testPath setFillColor:[UIColor clearColor]];
-	[testPath setLineWidth:40.0f];
-	[testPath setDrawingMode:kCGPathStroke];
+	[testPath setLineWidth:4.0f];
+    [testPath setShadowColor:[UIColor colorWithWhite:0.0 alpha:0.8]];
+    [testPath setShadowBlur:4.0];
+    [testPath setShadowOffset:CGSizeMake(0, 4)];
 	[testPath addLineToLatLong:one];
 	[testPath addLineToLatLong:two];
 	[testPath addLineToLatLong:three];
@@ -108,8 +110,7 @@
 	testRegion = [[RMPath alloc] initWithContents:mapContents];
 	[testRegion setFillColor:[UIColor colorWithRed: 0.1 green:0.1 blue: 0.8 alpha: 0.5 ]];
 	[testRegion setLineColor:[UIColor blueColor]];
-	[testRegion setLineWidth:20.0f];
-	[testRegion setDrawingMode:kCGPathFillStroke];
+	[testRegion setLineWidth:2.0f];
 	[testRegion addLineToLatLong:r1];
 	[testRegion addLineToLatLong:r2];
 	[testRegion addLineToLatLong:r3];


### PR DESCRIPTION
In response to comment https://github.com/route-me/route-me/pull/165#issuecomment-4602786, cap/join and shadow added.

Note: drawing mode is selected automatically based on the presence of fill/stroke options.
