### PR TITLE
Fixed false positive issue in RMMarkerManager managingMarker.

### DIFF
--- a/MapView/Map/RMMarkerManager.m
+++ b/MapView/Map/RMMarkerManager.m
@@ -162,7 +162,8 @@
 /// \deprecated violates Objective-C naming rules
 - (BOOL) managingMarker:(RMMarker*)marker
 {
-	if (marker != nil && [[self markers] indexOfObject:marker] != NSNotFound) {
+    NSArray *markers = [self markers];
+	if (marker != nil && markers != nil && [markers indexOfObject:marker] != NSNotFound) {
 		return YES;
 	}
 	return NO;


### PR DESCRIPTION
If called early it returns a false positive, as markers is nil.

Although this method is deprecated, it's better to fix it if we still have the code. I have some old code which used this method and it cost me an hour trying to track it down :)
