### PR TITLE
tile loading improvement - fixes crashs when deallocating owning vc while tiles are loading 

### DIFF
--- a/MapView/Map/RMURLConnectionOperation.h
+++ b/MapView/Map/RMURLConnectionOperation.h
@@ -28,14 +28,10 @@
 
 #import <Foundation/Foundation.h>
 
-@interface RMURLConnectionOperation : NSOperation {
-    id                      _delegate;
-    NSURLConnection         *_connection;
-    NSURLRequest            *_request;
-    BOOL                    _isRunning;
-}
+@protocol RMURLConnectionOperationDelegate;
 
--(id)initWithRequest:(NSURLRequest *)request delegate:(id)delegate;
--(void)stop;
+@interface RMURLConnectionOperation : NSOperation
+
+- (id)initWithRequest:(NSURLRequest *)request delegate:(id)delegate;
 
 @end

--- a/MapView/Map/RMURLConnectionOperation.m
+++ b/MapView/Map/RMURLConnectionOperation.m
@@ -27,38 +27,116 @@
 
 #import "RMURLConnectionOperation.h"
 
-@implementation RMURLConnectionOperation
+@interface RMURLConnectionOperation () <NSURLConnectionDelegate, NSURLConnectionDataDelegate>
+@property(retain) NSURLConnection *connection;
+@property(retain) NSPort* port;
 
--(id)initWithRequest:(NSURLRequest *)request delegate:(id)delegate {
-    if((self = [super init]))
-    {
-        _delegate = delegate;
-        _request = [request retain];
-        _isRunning = YES;
+@property BOOL executing;
+@property BOOL finished;
+
+- (void)completeOperation;
+
+@end
+
+@implementation RMURLConnectionOperation 
+@synthesize connection = _connection;
+@synthesize executing = _executing;
+@synthesize finished = _finished;
+@synthesize port = _port;
+
+- (id)init {
+    [self doesNotRecognizeSelector:_cmd];
+    return nil;
+}
+
+- (id)initWithRequest:(NSURLRequest *)request delegate:(id)delegate
+{
+    self = [super init];
+    if (self) {
+        _connection = [[NSURLConnection alloc] initWithRequest:request delegate:delegate startImmediately:NO];
+        self.port = [NSPort port];
     }
     return self;
 }
 
--(void)main {
-    if ([self isCancelled] || !_isRunning)
-    {
-        return;
-    }
-    _connection = [[NSURLConnection alloc] initWithRequest:_request delegate:_delegate startImmediately:YES];
-    [_request release];_request = nil;
-    while (_isRunning && ![self isCancelled] && [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]]);
+- (void)dealloc {
+    
     [_connection cancel];
     [_connection release];
-    _connection = nil; 
-}
-
--(void)stop {
-    _isRunning = NO;
-}
-
--(void)dealloc {
-    [_request release];
+    
+    [[NSRunLoop mainRunLoop] removePort:self.port forMode:NSDefaultRunLoopMode];
+    [_port release];
+    
     [super dealloc];
+}
+
+#pragma mark - overridden NSOperation methods
+
+- (void)start
+{
+    // Always check for cancellation before launching the task.
+    if ([self isCancelled])
+    {
+        // Must move the operation to the finished state if it is canceled.
+        [self willChangeValueForKey:@"isFinished"];
+        
+        self.finished = YES;
+        
+        [self didChangeValueForKey:@"isFinished"];
+        return;
+    }
+    
+    // If the operation is not canceled, begin executing the task.
+    [self willChangeValueForKey:@"isExecuting"];
+    
+    //the magical run loop trick will force NSURLConnection to call the delegate methods on main thread 
+    [[NSRunLoop mainRunLoop] addPort:self.port forMode:NSDefaultRunLoopMode];
+    [_connection scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+    [self.connection start];
+    [[NSRunLoop mainRunLoop] run];
+
+    self.executing = YES;
+    
+    [self didChangeValueForKey:@"isExecuting"];
+}
+
+- (BOOL)isConcurrent
+{
+    return YES;
+}
+
+- (BOOL)isExecuting
+{
+    return self.executing;
+}
+
+- (BOOL)isFinished
+{
+    return self.finished;
+}
+
+- (void)cancel
+{
+    [super cancel];
+    
+    if ([self isExecuting]) {
+        [self.connection cancel];
+        [self completeOperation];
+    }
+}
+
+#pragma mark - private methods
+
+- (void)completeOperation 
+{
+    [self willChangeValueForKey:@"isFinished"];
+    [self willChangeValueForKey:@"isExecuting"];
+    
+    self.executing = NO;
+    self.finished = YES;
+    
+    [self didChangeValueForKey:@"isExecuting"];
+    [self didChangeValueForKey:@"isFinished"];
 }
 
 @end

--- a/MapView/Map/RMWebTileImage.h
+++ b/MapView/Map/RMWebTileImage.h
@@ -57,8 +57,6 @@ extern NSString *RMWebTileImageNotificationErrorKey;
 	NSMutableData *data;
 }
 
-- (id) initWithTile: (RMTile)tile FromURL:(NSString*)url;
-- (void) requestTile;
-- (void) startLoading:(NSTimer *)timer;
+- (id)initWithTile:(RMTile)tile FromURL:(NSString*)url;
 
 @end

--- a/MapView/Map/RMWebTileImage.m
+++ b/MapView/Map/RMWebTileImage.m
@@ -37,12 +37,17 @@ NSString *RMWebTileImageNotificationErrorKey = @"RMWebTileImageNotificationError
 
 static NSOperationQueue *_queue = nil;
 
+@interface RMWebTileImage () <NSURLConnectionDelegate, NSURLConnectionDataDelegate>
+- (void)requestTile;
+- (void)startLoading:(NSTimer *)timer;
+@end
+
 @implementation RMWebTileImage
 
-+(void) initialize
++ (void) initialize
 {
     _queue = [[NSOperationQueue alloc] init];
-    [_queue setMaxConcurrentOperationCount: kMaxConcurrentConnections];
+    [_queue setMaxConcurrentOperationCount:kMaxConcurrentConnections];
 }
 
 - (id) initWithTile: (RMTile)_tile FromURL:(NSString*)urlStr
@@ -58,8 +63,8 @@ static NSOperationQueue *_queue = nil;
 
     connectionOp = nil;
 		
-	data =[[NSMutableData alloc] initWithCapacity:0];
-	
+    data =[[NSMutableData alloc] initWithCapacity:0];
+    
 	retries = kWebTileRetries;
 	
 	[[NSNotificationCenter defaultCenter] postNotificationName:RMTileRequested object:self];
@@ -75,9 +80,9 @@ static NSOperationQueue *_queue = nil;
 	
     if ( lastError ) [lastError release]; lastError = nil;
 	
-	[data release];
-	data = nil;
-	
+    [data release];
+    data = nil;
+    
 	[url release];
 	url = nil;
 	
@@ -87,7 +92,7 @@ static NSOperationQueue *_queue = nil;
 - (void) requestTile
 {
 	//RMLog(@"fetching: %@", url);
-	if(connectionOp) // re-request
+	if (connectionOp) // re-request
 	{
 		//RMLog(@"Refetching: %@: %d", url, retries);
 		
@@ -115,7 +120,7 @@ static NSOperationQueue *_queue = nil;
 	}
 }
 
-- (void) startLoading:(NSTimer *)timer
+- (void)startLoading:(NSTimer *)timer
 {
 	NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:30.0];
 
@@ -137,52 +142,34 @@ static NSOperationQueue *_queue = nil;
 	
 	[[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:self];
 	
-    [connectionOp stop];	
+    [connectionOp cancel];	
 	[connectionOp release];
 	connectionOp = nil;
     
-     if ( lastError ) [lastError release]; lastError = nil;
+    if (lastError) [lastError release]; lastError = nil;
     
 	[super cancelLoading];
 }
 
-#pragma mark URL loading functions
-// Delegate methods for loading the image
 
-//– connection:didCancelAuthenticationChallenge:  delegate method  
-//– connection:didReceiveAuthenticationChallenge:  delegate method  
-//Connection Data and Responses
-//– connection:willCacheResponse:  delegate method  
-//– connection:didReceiveResponse:  delegate method  
-//– connection:didReceiveData:  delegate method  
-//– connection:willSendRequest:redirectResponse:  delegate method  
-//Connection Completion
-//– connection:didFailWithError:  delegate method
-//– connectionDidFinishLoading:  delegate method 
+#pragma mark - NSURLConnectionDelegate
 
-- (void)connection:(NSURLConnection *)_connection didReceiveResponse:(NSURLResponse *)response
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
 {
-    if ( ![NSThread isMainThread] ) {
-        // Perform this on the main thread
-        dispatch_sync(dispatch_get_main_queue(), ^{ [self connection:_connection didReceiveResponse:response]; });
-        return;
-    }
+    int statusCode = NSURLErrorUnknown; // unknown
     
-	int statusCode = NSURLErrorUnknown; // unknown
-
-	if([response isKindOfClass:[NSHTTPURLResponse class]])
-	  statusCode = [(NSHTTPURLResponse*)response statusCode];
-		
-	[data setLength:0];
+	if ([response isKindOfClass:[NSHTTPURLResponse class]])
+        statusCode = [(NSHTTPURLResponse*)response statusCode];
 	
-        /// \bug magic number
-	if(statusCode < 400) // Success
-	{
+    [data setLength:0];
+    
+    /// \bug magic number
+	if(statusCode < 400) { // Success
 	}
-        /// \bug magic number
-	else if(statusCode == 404) // Not Found
-	{
-        [super displayProxy:[RMTileProxy missingTile]];
+    
+    /// \bug magic number
+	else if (statusCode == 404) { // Not Found
+	    [super displayProxy:[RMTileProxy missingTile]];
         
         NSError *error = [NSError errorWithDomain:RMWebTileImageErrorDomain 
                                              code:RMWebTileImageErrorNotFoundResponse
@@ -192,15 +179,14 @@ static NSOperationQueue *_queue = nil;
         [[NSNotificationCenter defaultCenter] postNotificationName:RMTileError object:self userInfo:[NSDictionary dictionaryWithObject:error forKey:RMWebTileImageNotificationErrorKey]];
 		[self cancelLoading];
 	}
-	else // Other Error
-	{
-		//RMLog(@"didReceiveResponse %@ %d", _connection, statusCode);
+    
+	else {  // Other Error
+        //RMLog(@"didReceiveResponse %@ %d", _connection, statusCode);
 
 		BOOL retry = FALSE;
 		
-		switch(statusCode)
-		{
-                        /// \bug magic number
+		switch(statusCode) {
+                /// \bug magic number
 			case 500: retry = TRUE; break;
 			case 503: retry = TRUE; break;
 		}
@@ -211,54 +197,44 @@ static NSOperationQueue *_queue = nil;
                                                    [NSNumber numberWithInt:statusCode], RMWebTileImageHTTPResponseCodeKey,
                                                    [NSString stringWithFormat:NSLocalizedString(@"The server returned error code %d", @""), statusCode], NSLocalizedDescriptionKey, nil]];
         
-		if(retry)
-		{
+		if (retry) {
             if ( lastError ) [lastError release];
             lastError = [error retain];
 			[self requestTile];
-		}
-		else 
-		{
+		} else {
 			[[NSNotificationCenter defaultCenter] postNotificationName:RMTileError object:self userInfo:[NSDictionary dictionaryWithObject:error forKey:RMWebTileImageNotificationErrorKey]];
 			[self cancelLoading];
 		}
 	}
 }
 
-- (void)connection:(NSURLConnection *)_connection didReceiveData:(NSData *)newData
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)newData
 {
 	[data appendData:newData];
 }
 
-- (void)connection:(NSURLConnection *)_connection didFailWithError:(NSError *)error
+- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
 {
-	//RMLog(@"didFailWithError %@ %d %@", _connection, [error code], [error localizedDescription]);
-    if ( ![NSThread isMainThread] ) {
-        // Perform this on the main thread
-        dispatch_sync(dispatch_get_main_queue(), ^{ [self connection:_connection didFailWithError:error]; });
-        return;
-    }
-    
-	BOOL retry = FALSE;
+    BOOL retry = FALSE;
 	
 	switch([error code])
 	{
-          case NSURLErrorBadURL:                      // -1000
-          case NSURLErrorTimedOut:                    // -1001
-          case NSURLErrorUnsupportedURL:              // -1002
-          case NSURLErrorCannotFindHost:              // -1003
-          case NSURLErrorCannotConnectToHost:         // -1004
-          case NSURLErrorNetworkConnectionLost:       // -1005
-          case NSURLErrorDNSLookupFailed:             // -1006
-          case NSURLErrorResourceUnavailable:         // -1008
-          case NSURLErrorNotConnectedToInternet:      // -1009
+        case NSURLErrorBadURL:                      // -1000
+        case NSURLErrorTimedOut:                    // -1001
+        case NSURLErrorUnsupportedURL:              // -1002
+        case NSURLErrorCannotFindHost:              // -1003
+        case NSURLErrorCannotConnectToHost:         // -1004
+        case NSURLErrorNetworkConnectionLost:       // -1005
+        case NSURLErrorDNSLookupFailed:             // -1006
+        case NSURLErrorResourceUnavailable:         // -1008
+        case NSURLErrorNotConnectedToInternet:      // -1009
             retry = TRUE; 
             break;
 	}
 	
 	if(retry)
 	{
-        if ( lastError ) [lastError release];
+        if (lastError) [lastError release];
         lastError = [error retain];
         
 		[self requestTile];
@@ -270,17 +246,10 @@ static NSOperationQueue *_queue = nil;
 	}
 }
 
-- (void)connectionDidFinishLoading:(NSURLConnection *)_connection
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection
 {
-    if ( ![NSThread isMainThread] ) {
-        // Perform this on the main thread
-        dispatch_sync(dispatch_get_main_queue(), ^{ [self connectionDidFinishLoading:_connection]; });
-        return;
-    }
-    
-	if ([data length] == 0) 
-    {
-		//RMLog(@"connectionDidFinishLoading %@ data size %d", _connection, [data length]);
+    if ([data length] == 0) {
+        //RMLog(@"connectionDidFinishLoading %@ data size %d", _connection, [data length]);
         
         if ( lastError ) [lastError release];
         lastError = [[NSError errorWithDomain:RMWebTileImageErrorDomain 
@@ -288,9 +257,7 @@ static NSOperationQueue *_queue = nil;
                                      userInfo:[NSDictionary dictionaryWithObjectsAndKeys:
                                                NSLocalizedString(@"The server returned a zero-length response", @""), NSLocalizedDescriptionKey, nil]] retain];
 		[self requestTile];
-	}
-	else
-	{
+	} else {
 		if ( ![self updateImageUsingData:data] ) {
             if ( lastError ) [lastError release];
             lastError = [[NSError errorWithDomain:RMWebTileImageErrorDomain 
@@ -301,15 +268,17 @@ static NSOperationQueue *_queue = nil;
             return;
         }
 		
-		[data release];
+        [data release];
 		data = nil;
+        
 		[url release];
 		url = nil;
-        [connectionOp stop];
+        
+        [connectionOp cancel];
 		[connectionOp release];
 		connectionOp = nil;
- 
-		if ( lastError ) [lastError release]; lastError = nil;
+        
+		if (lastError) [lastError release]; lastError = nil;
         
 		[[NSNotificationCenter defaultCenter] postNotificationName:RMTileRetrieved object:self];
 	}


### PR DESCRIPTION
Fixed bug: 
When scrolling the map fast and the map view is deallocated (e.g. UINavigationViewController pops the owner VC), still loading tiles forces a crash. 

Technical bug description:
When dispatching from loading thread to main thread after image load, the dispatches are sued when main run loop is busy. While this time, the RMWebTileImage is deallocated... the call gets dispatched into a deallocated object.

How it is fixed: 
It's fixed by changing the RMURLConnectionOperation from non-concurrent to concurrent behavior and schedule the NSURLConnection into MainRunloop instead of running a new thread. 
The NSURLConnection delegate is now called on the main thread. Dispatch to main thread is no longer needed. 
It still works asynchronously and perhaps a bit faster ;)
